### PR TITLE
docs: centralized documentation module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install dependencies
+uv sync
+
+# Run the API (dev mode)
+uv run uvicorn app.main:app --reload
+
+# Run all tests
+uv run pytest
+
+# Run a single test file
+uv run pytest tests/test_forecast.py
+
+# Run a single test
+uv run pytest tests/test_forecast.py::test_name
+
+# Run tests with coverage
+uv run pytest --cov=app --cov-report=term-missing
+
+# Run all pre-commit hooks (black, flake8, pylint, mypy)
+uv run pre-commit run --all-files
+
+# Full local stack (API + Prometheus + Grafana)
+docker compose up --build
+```
+
+## Architecture
+
+The app is a FastAPI service (`app/`) with a Prometheus + Grafana monitoring stack and a Locust load testing runner (`load/`). Infrastructure lives in `infra/` as Terraform targeting AWS.
+
+**Request lifecycle:** Every request passes through `ApiKeyMiddleware` (`app/middleware.py`) which validates the `X-API-Key` header, then delegates to the router, and records metrics post-response. Paths `/docs`, `/openapi.json`, `/healthz`, and `/metrics` bypass auth.
+
+**Metrics:** `app/monitoring.py` owns three custom Prometheus metrics (`forecast_api_requests_total`, `forecast_api_errors_total`, `forecast_api_request_duration_seconds`) plus three process gauges. The middleware calls `observe_request()` after every instrumented response. The `/metrics` endpoint itself is excluded from instrumentation to avoid loops.
+
+**Two environments:** Terraform workspaces `staging` (branch `develop`) and `prod` (branch `main`). CD runs via GitHub Actions → AWS SSM (no SSH). Secrets live in AWS Secrets Manager and are injected into `.env` at deploy time by `scripts/write_runtime_env.sh`.
+
+**Grafana and Prometheus** are provisioned automatically from `grafana/provisioning/` and `grafana/dashboards/`. No manual setup needed locally or in prod.
+
+## Code standards
+
+- **Formatter:** Black (max line length 88). Config in `.pre-commit/.black.toml`.
+- **Linter:** flake8 + pylint. Config in `.pre-commit/.flake8` and `.pre-commit/.pylintrc`.
+- **Types:** mypy with `disallow_untyped_defs = True`. All functions must be fully typed.
+- Pre-commit runs all four tools. CI enforces the same checks.
+
+## Tests
+
+Tests use `httpx.TestClient` against the FastAPI app. The `API_KEY` env var is set in `tests/conftest.py` via `tests.TEST_API_KEY = "abcdef12345"` — use that constant in any new test that needs auth headers.
+
+```python
+from tests import TEST_API_KEY
+headers = {"X-API-Key": TEST_API_KEY}
+```
+
+## Key constraints
+
+- The forecast model is mock/linear only: `max(base_value - 7.5 * day_index, 0)`. Valid wells: `POZO-001`, `POZO-002`, `POZO-003`.
+- Locust is not part of `docker compose up`. Run it separately; see [`docs/load-testing.md`](docs/load-testing.md).
+- Never commit `.env` or real secret values. Use `TF_VAR_*` for Terraform sensitive vars.

--- a/README.md
+++ b/README.md
@@ -1,171 +1,51 @@
 # Plataforma Predictiva de Producción de Hidrocarburos
 
-API REST para consultar pozos disponibles y generar pronósticos mock de producción.
-El repositorio también incluye una base de monitoreo técnico con Prometheus y Grafana,
-y un runner separado de tráfico sintético con Locust.
+API REST para consultar pozos disponibles y generar pronósticos mock de producción,
+con monitoreo técnico (Prometheus + Grafana) y tráfico sintético (Locust).
 
-## Qué resuelve y stack principal
+Stack principal: FastAPI · Python 3.10+ · uv · Docker Compose · Prometheus · Grafana · Terraform (AWS)
 
-Este proyecto centraliza una API simple para exponer información operativa y
-proveer un punto de integración para pruebas, monitoreo y validaciones locales.
+## Documentación
 
-Stack principal:
+La documentación técnica completa está en [`docs/`](docs/index.md):
 
-- FastAPI para la API REST
-- Python 3.10+ y [uv](https://docs.astral.sh/uv/) para entorno y dependencias
-- Docker Compose para levantar el stack local
-- Prometheus y Grafana para monitoreo técnico
-- Locust para tráfico sintético, documentado en [`load/README.md`](load/README.md)
+- [Arquitectura](docs/architecture.md) — componentes, stack y flujo de un request
+- [API Reference](docs/api-reference.md) — endpoints, autenticación y ejemplos
+- [Infraestructura](docs/infrastructure.md) — recursos AWS y ambientes staging/prod
+- [Monitoreo](docs/monitoring.md) — Prometheus, Grafana y métricas
+- [Load Testing](docs/load-testing.md) — tráfico sintético con Locust
+- [Ops](docs/ops.md) — deploy, secretos y monitoreo operativo
 
 ## Requisitos
 
 - Python 3.10 o superior
 - [uv](https://docs.astral.sh/uv/)
-- Docker y Docker Compose para el stack completo de monitoreo
+- Docker y Docker Compose
 
 ## Inicio rápido local con `uv`
 
-1. Clonar el repositorio y entrar al directorio del proyecto:
-
-```bash
-git clone <repo-url>
-cd ingenieria-software
-```
-
-2. Instalar dependencias:
-
 ```bash
 uv sync
-```
-
-3. Crear el archivo de entorno local:
-
-```bash
-cp .env.example .env
-```
-
-`.env.example` trae valores base para desarrollo local. Completá la contraseña de Grafana en tu `.env`; ese archivo está ignorado por git y no debe commitearse.
-
-```env
-API_KEY=api_key
-GF_SECURITY_ADMIN_USER=admin
-GF_SECURITY_ADMIN_PASSWORD=<tu-password-local>
-```
-
-4. Levantar la API en modo desarrollo:
-
-```bash
+cp .env.example .env   # completar GF_SECURITY_ADMIN_PASSWORD
 uv run uvicorn app.main:app --reload
 ```
 
-Puntos de acceso útiles:
-
-- API: `http://localhost:8000`
-- Documentación interactiva: `http://localhost:8000/docs`
-- OpenAPI: `http://localhost:8000/openapi.json`
-- Health check: `http://localhost:8000/healthz`
-- Métricas: `http://localhost:8000/metrics`
+Puntos de acceso: API `http://localhost:8000` · Docs `http://localhost:8000/docs`
 
 ## Inicio rápido con Docker Compose
-
-Con el mismo archivo `.env`, podés levantar la API junto con Prometheus y Grafana:
 
 ```bash
 docker compose up --build
 ```
 
-Servicios disponibles:
+Servicios: API `:8000` · Prometheus `:9090` · Grafana `:3000`
 
-- API: `http://localhost:8000`
-- Documentación interactiva: `http://localhost:8000/docs`
-- Health check: `http://localhost:8000/healthz`
-- Métricas: `http://localhost:8000/metrics`
-- Prometheus: `http://localhost:9090`
-- Grafana: `http://localhost:3000`
-
-Credenciales locales de Grafana:
-
-```text
-usuario: admin
-password: el valor de GF_SECURITY_ADMIN_PASSWORD en tu .env
-```
-
-Notas del stack local:
-
-- `api` corre como servicio independiente dentro de Compose
-- `prometheus` usa la configuración bakeada en `prometheus/prometheus.yml`
-- `grafana` se levanta con datasource y dashboard provisionados
-- Locust no forma parte de `docker compose up --build`; se ejecuta por separado
+Credenciales de Grafana: usuario `admin`, contraseña = `GF_SECURITY_ADMIN_PASSWORD` en `.env`.
 
 ## Testing y calidad
-
-Comandos útiles para validar el proyecto localmente:
 
 ```bash
 uv run pytest
 uv run pytest --cov=app --cov-report=term-missing
 uv run pre-commit run --all-files
 ```
-
-La pipeline de CI ejecuta tests y hooks de `pre-commit` con esta misma base.
-
-## Deploy y secretos
-
-Terraform crea secretos por ambiente en AWS Secrets Manager para `API_KEY` y la
-contraseña admin de Grafana. Pasalos como variables sensibles, por ejemplo con
-`TF_VAR_api_key` y `TF_VAR_grafana_admin_password`, sin commitear valores reales.
-
-En cada deploy, la EC2 regenera `/opt/app/.env` desde Secrets Manager antes de
-levantar el stack. Grafana usa `GF_SECURITY_ADMIN_USER=admin` y
-`GF_SECURITY_ADMIN_PASSWORD` desde ese archivo; si el volumen ya existía, el
-deploy también resincroniza la contraseña del usuario admin dentro del contenedor.
-
-## Estructura resumida del proyecto
-
-```text
-app/
-├── main.py              # Entrada de FastAPI y registro de routers
-├── middleware.py        # Validación global de API key
-├── health.py            # Health check técnico
-├── monitoring.py        # Métricas Prometheus
-├── forecast/            # Endpoint de pronóstico
-└── wells/               # Endpoint de consulta de pozos
-grafana/
-├── dashboards/          # Dashboard provisionado
-└── provisioning/        # Datasource y carga automática
-prometheus/
-└── prometheus.yml       # Configuración de scrape local
-load/
-├── config/              # Presets de Locust
-├── env/                 # Env files de ejemplo
-├── locustfile.py        # Runner de tráfico sintético
-└── README.md            # Documentación específica de Locust
-tests/                   # Suite de tests
-Dockerfile               # Imagen de la API
-docker-compose.yml       # Stack local de API + Prometheus + Grafana
-pyproject.toml           # Configuración del proyecto y dependencias
-```
-
-Además, el repo conserva directorios auxiliares como `app/static/` y `app/dashboard/`.
-
-## Autenticación y endpoints
-
-Los endpoints de negocio requieren el header `X-API-Key`. El valor esperado se
-configura con la variable de entorno `API_KEY`.
-
-Endpoints principales:
-
-- `GET /api/v1/wells`: devuelve la lista de pozos disponibles para una fecha.
-- `GET /api/v1/forecast`: devuelve un pronóstico mock de producción para un pozo y un rango de fechas.
-- `GET /healthz`: expone un health check técnico sin autenticación.
-- `GET /metrics`: expone métricas en formato Prometheus sin autenticación.
-
-Los endpoints `GET /api/v1/wells` y `GET /api/v1/forecast` también están
-documentados en `http://localhost:8000/docs`, que es la referencia recomendada
-para revisar parámetros, validaciones y respuestas del contrato OpenAPI.
-
-## Documentación relacionada
-
-- [`load/README.md`](load/README.md): uso del runner de tráfico sintético con Locust.
-- `grafana/`: dashboard y provisioning del stack de monitoreo local.
-- `prometheus/`: configuración de scrape para la API.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,125 @@
+# API Reference
+
+Base URL: `http://localhost:8000` (local) o `http://<EC2_IP>:8000` (prod).
+
+Documentación interactiva disponible en `/docs`.
+
+## Autenticación
+
+Los endpoints de negocio requieren el header `X-API-Key` con el valor configurado en la variable de entorno `API_KEY`.
+
+```
+X-API-Key: <valor de API_KEY>
+```
+
+**Rutas que no requieren autenticación:** `/docs`, `/openapi.json`, `/healthz`, `/metrics`.
+
+**Errores de autenticación:**
+
+| Código | Condición | Cuerpo |
+|--------|-----------|--------|
+| 403 | Header ausente o valor incorrecto | `{"detail": "Invalid or missing API key"}` |
+| 500 | Variable `API_KEY` no configurada | `{"detail": "API_KEY is not configured"}` |
+
+---
+
+## GET /api/v1/wells
+
+Devuelve la lista de pozos disponibles para una fecha dada.
+
+**Parámetros de query:**
+
+| Nombre | Tipo | Requerido | Descripción |
+|--------|------|-----------|-------------|
+| `date_query` | `date` (YYYY-MM-DD) | Sí | Fecha de consulta |
+
+**Respuesta 200:**
+
+```json
+{
+  "date_query": "2025-02-10",
+  "wells": ["POZO-001", "POZO-002", "POZO-003"]
+}
+```
+
+---
+
+## GET /api/v1/forecast
+
+Devuelve un pronóstico mock de producción con tendencia lineal decreciente para un pozo y rango de fechas.
+
+**Parámetros de query:**
+
+| Nombre | Tipo | Requerido | Descripción |
+|--------|------|-----------|-------------|
+| `id_well` | `string` | Sí | Identificador del pozo |
+| `date_start` | `date` (YYYY-MM-DD) | Sí | Fecha inicial |
+| `date_end` | `date` (YYYY-MM-DD) | Sí | Fecha final |
+
+**Pozos válidos:**
+
+| Pozo | Producción base (BOPD) |
+|------|------------------------|
+| `POZO-001` | 1200.0 |
+| `POZO-002` | 980.0 |
+| `POZO-003` | 760.0 |
+
+**Algoritmo de pronóstico:**
+
+```
+producción(día i) = max(base_value - 7.5 × i, 0)
+```
+
+Donde `i` es el índice del día (0 = `date_start`).
+
+**Respuesta 200:**
+
+```json
+{
+  "id_well": "POZO-001",
+  "date_start": "2025-02-10",
+  "date_end": "2025-02-12",
+  "trend": "linear_decreasing",
+  "data": [
+    {"date": "2025-02-10", "oil_bopd": 1200.0},
+    {"date": "2025-02-11", "oil_bopd": 1192.5},
+    {"date": "2025-02-12", "oil_bopd": 1185.0}
+  ]
+}
+```
+
+**Errores:**
+
+| Código | Condición | Cuerpo |
+|--------|-----------|--------|
+| 404 | `id_well` no existe | `{"detail": "Pozo no encontrado"}` |
+| 400 | `date_end` < `date_start` | `{"detail": "date_end debe ser mayor o igual a date_start"}` |
+
+---
+
+## GET /healthz
+
+Health check técnico para probes de infraestructura. No requiere autenticación.
+
+**Respuesta 200:**
+
+```json
+{"status": "ok"}
+```
+
+---
+
+## GET /metrics
+
+Expone métricas en formato Prometheus. No requiere autenticación.
+
+**Métricas expuestas:**
+
+| Métrica | Tipo | Descripción |
+|---------|------|-------------|
+| `forecast_api_requests_total` | Counter | Requests totales por `method`, `path`, `status_code` |
+| `forecast_api_errors_total` | Counter | Respuestas de error (4xx/5xx) por `method`, `path`, `status_code` |
+| `forecast_api_request_duration_seconds` | Histogram | Latencia por request en segundos |
+| `process_resident_memory_bytes` | Gauge | Memoria residente del proceso |
+| `process_cpu_seconds_total` | Counter | CPU total (usuario + sistema) |
+| `process_start_time_seconds` | Gauge | Tiempo de inicio del proceso (epoch Unix) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,79 @@
+# Arquitectura
+
+## Qué resuelve
+
+La plataforma expone una API REST para consultar pozos de hidrocarburos disponibles y generar pronósticos mock de producción. Incluye un stack de monitoreo técnico (Prometheus + Grafana) y un runner de tráfico sintético (Locust) para validar el comportamiento bajo carga.
+
+## Diagrama de componentes
+
+```
+                        ┌─────────────────────────────────────────┐
+                        │              AWS EC2 Instance            │
+                        │                                         │
+  Cliente / Locust ────►│  FastAPI :8000                          │
+                        │      │                                  │
+                        │      │ /metrics (scrape cada 5s)        │
+                        │      ▼                                  │
+                        │  Prometheus :9090                       │
+                        │      │                                  │
+                        │      │ datasource                       │
+                        │      ▼                                  │
+                        │  Grafana :3000                          │
+                        └─────────────────────────────────────────┘
+
+  GitHub Actions ──────► ECR (imagen Docker) ────► EC2 (deploy vía SSM)
+```
+
+## Stack tecnológico
+
+| Tecnología | Rol |
+|-----------|-----|
+| **FastAPI** | Framework HTTP — tipado, validación automática, OpenAPI generado |
+| **Uvicorn** | ASGI server de producción |
+| **Python 3.10+** | Lenguaje principal |
+| **uv** | Gestión de dependencias y entorno virtual |
+| **Docker + Compose** | Empaquetado y orquestación local/prod |
+| **Prometheus** | Recolección de métricas de la API |
+| **Grafana** | Visualización de métricas en tiempo real |
+| **Locust** | Tráfico sintético para stress testing y poblado del dashboard |
+| **Terraform** | Infraestructura como código (IaC) en AWS |
+| **GitHub Actions** | CI (lint + tests) y CD (build + deploy) |
+
+## Estructura de módulos (`app/`)
+
+```
+app/
+├── main.py         # Punto de entrada: instancia FastAPI, registra routers y middleware
+├── middleware.py   # Validación de API key + instrumentación de métricas por request
+├── health.py       # Endpoint /healthz para probes de infraestructura
+├── monitoring.py   # Métricas Prometheus y endpoint /metrics
+├── wells/
+│   └── routes.py   # GET /api/v1/wells — lista de pozos para una fecha
+└── forecast/
+    └── routes.py   # GET /api/v1/forecast — pronóstico de producción para un pozo
+```
+
+## Flujo de un request
+
+```
+Cliente
+  │
+  │  GET /api/v1/forecast?id_well=POZO-001&...
+  │  X-API-Key: <api_key>
+  ▼
+ApiKeyMiddleware
+  ├─ ¿ruta excluida? (/docs, /metrics, /healthz) → pasa directo
+  ├─ ¿API_KEY configurada? → sino, 500
+  ├─ ¿header X-API-Key válido? → sino, 403
+  └─ llama al endpoint
+        │
+        ▼
+  ForecastRouter
+  ├─ valida id_well (POZO-001/002/003) → sino, 404
+  ├─ valida date_end >= date_start → sino, 400
+  └─ calcula pronóstico lineal → 200 JSON
+        │
+        ▼
+  ApiKeyMiddleware (post-response)
+  └─ registra métricas (duración, status code, errores)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# Documentación — Plataforma Predictiva de Producción de Hidrocarburos
+
+## Índice
+
+| Documento | Descripción |
+|-----------|-------------|
+| [Arquitectura](architecture.md) | Visión general del sistema, componentes y flujo de un request |
+| [API Reference](api-reference.md) | Endpoints, autenticación, parámetros y respuestas |
+| [Infraestructura](infrastructure.md) | Recursos AWS, ambientes (staging/prod) e IaC con Terraform |
+| [Monitoreo](monitoring.md) | Stack Prometheus + Grafana, métricas y dashboard |
+| [Load Testing](load-testing.md) | Tráfico sintético con Locust, presets y ejecución |
+| [Ops](ops.md) | Deploy, secretos y monitoreo operativo en alto nivel |

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -1,0 +1,41 @@
+# Infraestructura
+
+La infraestructura está definida como código con Terraform en el directorio `infra/`. Se despliega en AWS y soporta dos ambientes independientes mediante workspaces.
+
+## Ambientes
+
+| Workspace | Rama git | Uso |
+|-----------|----------|-----|
+| `staging` | `develop` | Validación pre-producción |
+| `prod` | `main` | Producción |
+
+Cada workspace crea sus propios recursos aislados en AWS.
+
+## Backend de estado
+
+El estado de Terraform se almacena en S3:
+
+- **Bucket**: `ing-soft-tf-state`
+- **Región**: `us-east-2`
+
+## Recursos por ambiente
+
+| Recurso | Detalle |
+|---------|---------|
+| **EC2** | `t3.micro`, Amazon Linux 2023; ejecuta el stack Docker Compose |
+| **ECR** | Repositorio `api-{workspace}`; lifecycle policy retiene las últimas 5 imágenes |
+| **Secrets Manager** | `api/api-key-{workspace}` y `grafana/admin-password-{workspace}` |
+| **Security Group** | Inbound en puertos 8000 (API), 3000 (Grafana), 9090 (Prometheus) |
+| **IAM Instance Profile** | Permite a la EC2 leer de ECR y Secrets Manager |
+| **IAM OIDC Role** | Solo en `prod`; usado por GitHub Actions para asumir permisos de deploy |
+
+## Variables sensibles
+
+Los valores reales nunca se commitean. Se pasan como variables de entorno al momento de aplicar:
+
+```bash
+TF_VAR_api_key=<valor>
+TF_VAR_grafana_admin_password=<valor>
+```
+
+En producción, los secretos viven en AWS Secrets Manager. La EC2 los lee al iniciar con el script `scripts/write_runtime_env.sh`.

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -1,0 +1,79 @@
+# Load Testing
+
+## Qué es Locust
+
+[Locust](https://locust.io/) es una herramienta de load testing que simula usuarios concurrentes haciendo requests HTTP a una API. En este proyecto se usa para dos propósitos: generar tráfico sintético que puebla el dashboard de Grafana/Prometheus y validar el comportamiento de la API bajo carga.
+
+## Mix de tráfico
+
+El tráfico simulado replica un patrón realista de uso:
+
+| Escenario | Proporción | Descripción |
+|-----------|------------|-------------|
+| Forecast exitoso | 75% | `GET /api/v1/forecast` con pozo y fechas válidos |
+| Wells exitoso | 18% | `GET /api/v1/wells` con fecha válida |
+| API key inválida | 4% | Request con key incorrecta → 403 |
+| Pozo inexistente | 3% | `GET /api/v1/forecast` con id_well inválido → 404 |
+
+Antes de entrar al loop principal, cada usuario ejecuta un **seed** de escenarios deterministas para asegurarse de que los paneles del dashboard tengan datos desde el inicio.
+
+## Presets
+
+Los presets viven en `load/config/` y se pasan con `--config`.
+
+| Preset | Modo | Uso recomendado |
+|--------|------|-----------------|
+| `ui` | Interfaz web en `:8089` | Exploración manual y demos |
+| `normal` | Headless, carga liviana | Poblar monitoreo, validación base |
+| `intense` | Headless, carga alta | Stress test sin ser destructivo |
+
+## Ejecución local (Docker)
+
+```bash
+# 1. Levantar el stack principal
+docker compose up --build
+
+# 2. Construir la imagen de Locust
+docker build -t forecast-traffic ./load
+
+# 3. Crear el archivo de entorno (una sola vez)
+cp load/env/local.docker.env.example load/env/local.docker.env
+
+# 4. Correr un preset
+docker run --rm \
+  --env-file load/env/local.docker.env \
+  forecast-traffic \
+  --config /load/config/normal.conf
+```
+
+Para la interfaz web (preset `ui`):
+
+```bash
+docker run --rm \
+  --env-file load/env/local.docker.env \
+  -p 8089:8089 \
+  forecast-traffic \
+  --config /load/config/ui.conf
+# Abrir http://127.0.0.1:8089
+```
+
+## Ejecución contra AWS
+
+Usá el archivo de entorno para el target remoto:
+
+```bash
+cp load/env/aws.env.example load/env/aws.env
+# Editá LOCUST_HOST con la IP pública de la EC2
+
+docker run --rm \
+  --env-file load/env/aws.env \
+  forecast-traffic \
+  --config /load/config/intense.conf
+```
+
+## Variables de entorno
+
+| Variable | Descripción |
+|----------|-------------|
+| `LOCUST_HOST` | Base URL de la API objetivo |
+| `API_KEY` | API key válida para requests exitosos |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,50 @@
+# Monitoreo
+
+El stack de monitoreo está compuesto por Prometheus y Grafana. Corre junto a la API dentro del mismo Docker Compose, tanto en local como en producción.
+
+## Stack
+
+```
+API /metrics  ──(scrape 5s)──►  Prometheus :9090  ──(datasource)──►  Grafana :3000
+```
+
+## Prometheus
+
+- Configuración en `prometheus/prometheus.yml`
+- Intervalo de scrape: **5 segundos**
+- Job: `forecast-api` — consume `/metrics` en `api:8000`
+
+## Grafana
+
+- Datasource provisionado automáticamente: `http://prometheus:9090` (UID: `prometheus-fase1`)
+- Dashboard provisionado: **"Fase 1 — Technical Monitoring"** (carpeta `Fase 1`)
+
+### Paneles del dashboard
+
+| Panel | Métrica principal | Qué muestra |
+|-------|-------------------|-------------|
+| Prometheus Scrape Status | `up{job="forecast-api"}` | Si el scrape está activo (Up/Down) |
+| Forecast Success Latency P95 | `histogram_quantile(0.95, ...)` | Latencia del percentil 95 en segundos |
+| HTTP Error Ratio | `errors / requests` | Proporción de respuestas 4xx/5xx |
+| API Request Rate | `rate(forecast_api_requests_total[5m])` | Requests por segundo |
+| Forecast Success Latency | P50 / P95 / P99 en serie temporal | Evolución de latencias |
+| API Query Frequency by Endpoint | Rate por path | Frecuencia de uso por endpoint |
+| HTTP Error Ratio by Status | Rate por código de error | Desglose de errores 4xx/5xx |
+| API Process Resource Usage | CPU + memoria del proceso | Consumo de recursos |
+
+## Métricas expuestas por la API
+
+| Métrica | Tipo | Labels |
+|---------|------|--------|
+| `forecast_api_requests_total` | Counter | `method`, `path`, `status_code` |
+| `forecast_api_errors_total` | Counter | `method`, `path`, `status_code` |
+| `forecast_api_request_duration_seconds` | Histogram | `method`, `path`, `status_code` |
+| `process_resident_memory_bytes` | Gauge | `pid` |
+| `process_cpu_seconds_total` | Counter | `pid` |
+| `process_start_time_seconds` | Gauge | `pid` |
+
+## Acceso local
+
+- Grafana: `http://localhost:3000`
+- Credenciales: `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD` del archivo `.env`
+- Prometheus: `http://localhost:9090`

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,0 +1,40 @@
+# Ops
+
+## Deploy
+
+El pipeline de CD se dispara automáticamente con cada push a las ramas principales:
+
+| Rama | Ambiente |
+|------|----------|
+| `develop` | staging |
+| `main` | prod |
+
+El CD detecta qué cambió y actúa en consecuencia:
+
+- Si cambiaron archivos de la API (`app/`, `Dockerfile`, `pyproject.toml`, `uv.lock`): construye una nueva imagen Docker y la sube a ECR.
+- Si cambiaron archivos del stack (`grafana/`, `prometheus/`, `docker-compose.prod.yml`) o la imagen: conecta a la EC2 via AWS SSM, hace pull de la imagen y reinicia el stack.
+
+No se requiere acceso SSH directo a la instancia.
+
+## Secretos
+
+Los secretos viven en **AWS Secrets Manager**:
+
+- `api/api-key-{env}` — API key de la aplicación
+- `grafana/admin-password-{env}` — contraseña admin de Grafana
+
+Al iniciar o reiniciar, la EC2 ejecuta `scripts/write_runtime_env.sh`, que lee ambos secretos y genera el archivo `.env` con permisos restringidos.
+
+Para **rotar un secreto**: actualizar el valor en AWS Secrets Manager y luego triggerear un nuevo deploy (push a la rama correspondiente). El próximo arranque del stack tomará el valor nuevo.
+
+## Monitoreo en producción
+
+- Grafana: `http://<EC2_IP>:3000`
+- Credenciales: las almacenadas en Secrets Manager (`grafana/admin-password-{env}`)
+- Prometheus: `http://<EC2_IP>:9090`
+
+La IP pública de la instancia está disponible como output de Terraform (`app_public_ip`).
+
+## Load testing remoto
+
+Para correr Locust contra el ambiente de producción o staging, ver [Load Testing](load-testing.md#ejecución-contra-aws). Conviene ejecutarlo cerca de la instancia para obtener latencias representativas.

--- a/load/README.md
+++ b/load/README.md
@@ -1,139 +1,19 @@
-# Tráfico Sintético con Locust
+# Load Testing
 
-Este directorio contiene el runner de tráfico sintético usado para poblar el
-dashboard de monitoreo y exigir la API sin acoplar la generación de carga al
-runtime de FastAPI.
+La documentación completa de tráfico sintético con Locust está en [`docs/load-testing.md`](../docs/load-testing.md).
 
-La forma recomendada de uso es un contenedor Docker separado del stack
-principal. Por diseño, Locust no forma parte de `docker compose up --build`.
-
-## Qué hay en este directorio
-
-- `load/locustfile.py`: define el comportamiento del tráfico.
-- `load/traffic_config.py`: helpers de configuración compartidos.
-- `load/config/`: presets nativos de Locust (`ui`, `normal`, `intense`).
-- `load/env/`: archivos de ejemplo para targets locales y remotos.
-
-## Variables y archivos de entorno
-
-Copiá el ejemplo que corresponda a tu escenario antes de ejecutar Locust:
-
-- `load/env/local.docker.env.example`: pensado para una API local levantada con Docker en `http://host.docker.internal:8000`.
-- `load/env/aws.env.example`: pensado para una API remota o desplegada cerca de AWS.
-
-Variables documentadas:
-
-- `LOCUST_HOST`: base URL de la API objetivo.
-- `API_KEY`: API key válida para requests exitosos.
-
-## Workflow local recomendado
-
-1. Levantar primero el stack principal:
+## Referencia rápida
 
 ```bash
-docker compose up --build
-```
-
-2. Construir la imagen de Locust:
-
-```bash
+# Construir imagen
 docker build -t forecast-traffic ./load
-```
 
-3. Crear el archivo de entorno local una única vez:
+# Preset normal (headless)
+docker run --rm --env-file load/env/local.docker.env forecast-traffic --config /load/config/normal.conf
 
-```bash
-cp load/env/local.docker.env.example load/env/local.docker.env
-```
+# Preset UI (interfaz web en :8089)
+docker run --rm --env-file load/env/local.docker.env -p 8089:8089 forecast-traffic --config /load/config/ui.conf
 
-4. Ejecutar uno de los presets disponibles.
-
-## Presets disponibles
-
-Todos los presets comparten el mismo modelo de tráfico:
-
-- una siembra corta al inicio para forzar respuestas `200`, `403` y `404`
-- luego un mix ponderado donde predominan las requests exitosas a `forecast`
-
-### Preset `ui`
-
-Abre la interfaz web de Locust para exploración manual desde el navegador.
-
-```bash
-docker run --rm \
-  --env-file load/env/local.docker.env \
-  -p 8089:8089 \
-  forecast-traffic \
-  --config /load/config/ui.conf
-```
-
-Luego abrir:
-
-```text
-http://127.0.0.1:8089
-```
-
-### Preset `normal`
-
-Genera tráfico liviano para poblar el monitoreo y validar comportamiento base.
-
-```bash
-docker run --rm \
-  --env-file load/env/local.docker.env \
-  forecast-traffic \
-  --config /load/config/normal.conf
-```
-
-### Preset `intense`
-
-Genera tráfico más agresivo para exigir más a la aplicación sin convertirlo,
-por defecto, en una prueba destructiva.
-
-```bash
-docker run --rm \
-  --env-file load/env/local.docker.env \
-  forecast-traffic \
-  --config /load/config/intense.conf
-```
-
-## Cuándo correr Locust cerca de AWS
-
-Ejecutarlo localmente está bien para:
-
-- smoke tests
-- demos
-- exploración manual de la UI
-- poblar el dashboard de monitoreo rápidamente
-
-Si la API corre en AWS, conviene ejecutar el contenedor de Locust cerca del
-servicio cuando quieras:
-
-- latencia más representativa
-- mayor capacidad de carga
-- acceso a APIs privadas dentro de una VPC
-
-Preparación del target remoto:
-
-```bash
-cp load/env/aws.env.example load/env/aws.env
-```
-
-Ejemplo de ejecución:
-
-```bash
-docker run --rm \
-  --env-file load/env/aws.env \
-  forecast-traffic \
-  --config /load/config/intense.conf
-```
-
-## Alternativa host-local sin Docker
-
-Docker es el runtime recomendado. Si necesitás correr Locust directamente desde
-el host, podés usar la instalación del proyecto y mantener los mismos presets:
-
-```bash
-LOCUST_HOST=http://127.0.0.1:8000 \
-API_KEY=api_key \
-uv run locust -f load/locustfile.py --config load/config/ui.conf
+# Preset intense
+docker run --rm --env-file load/env/local.docker.env forecast-traffic --config /load/config/intense.conf
 ```


### PR DESCRIPTION
## Summary

- Add `docs/` con 7 páginas Markdown: índice, arquitectura, API reference, infraestructura, monitoreo, load testing y ops
- Simplificar `README.md` para que actúe como punto de entrada liviano con links a `docs/`
- Simplificar `load/README.md` para redirigir a `docs/load-testing.md`
- Agregar `CLAUDE.md` con comandos de desarrollo, arquitectura y estándares de código

## Test plan

- [x] Verificar que todos los links en `docs/index.md` resuelven correctamente
- [x] Verificar que `README.md` no duplica contenido de `docs/`
- [x] Verificar que `load/README.md` apunta correctamente a `docs/load-testing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)