### PR TITLE
ci: add Trivy Docker image vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,22 @@ jobs:
 
       - name: Run tests with coverage
         run: uv run pytest --cov=app --cov-report=term-missing
+
+  scan:
+    runs-on: ubuntu-latest
+    needs: []
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build Docker image
+        run: docker build -t forecast-api:${{ github.sha }} .
+
+      - name: Scan image for vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: forecast-api:${{ github.sha }}
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: docker build -t forecast-api:${{ github.sha }} .
 
       - name: Scan image for vulnerabilities (Trivy)
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: forecast-api:${{ github.sha }}
           format: table

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.worktrees/


### PR DESCRIPTION
## Summary

- Agrega un nuevo job `scan` al pipeline de CI que corre **en paralelo** con `lint` y `test`
- Buildea la imagen Docker y la escanea con [Trivy](https://github.com/aquasecurity/trivy-action) buscando CVEs de severidad `CRITICAL` y `HIGH`

## Test plan

- [x] Verificar que el job `scan` aparece en el CI de este PR
- [x] Confirmar que el reporte de Trivy se ve en los logs del job
- [x] Confirmar que un eventual CVE no rompe el pipeline (exit-code 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)