### PR TITLE
Restore preferred Grafana dashboard layout

### DIFF
--- a/grafana/dashboards/fase1-technical-monitoring.json
+++ b/grafana/dashboards/fase1-technical-monitoring.json
@@ -61,12 +61,14 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "none",
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 6,
         "x": 0,
         "y": 0
@@ -118,29 +120,28 @@
               },
               {
                 "color": "yellow",
-                "value": 0.25
+                "value": 10
               },
               {
                 "color": "red",
-                "value": 0.5
+                "value": 25
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms",
+          "min": 0,
+          "max": 50
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 6,
         "x": 6,
         "y": 0
       },
       "id": 2,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -149,7 +150,8 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true
       },
       "targets": [
         {
@@ -160,8 +162,8 @@
           "refId": "A"
         }
       ],
-      "title": "Forecast Success Latency P95",
-      "type": "stat"
+      "title": "Forecast P95 Latency (ms)",
+      "type": "gauge"
     },
     {
       "datasource": {
@@ -183,20 +185,22 @@
               },
               {
                 "color": "yellow",
-                "value": 1
+                "value": 0.05
               },
               {
                 "color": "red",
-                "value": 5
+                "value": 0.1
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 0.25
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 6,
         "x": 12,
         "y": 0
@@ -246,12 +250,13 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "suffix: req/min",
+          "min": 0
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 4,
         "w": 6,
         "x": 18,
         "y": 0
@@ -325,7 +330,9 @@
               "mode": "off"
             }
           },
-          "unit": "s"
+          "decimals": 1,
+          "unit": "ms",
+          "min": 0
         },
         "overrides": [
           {
@@ -355,10 +362,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 12,
         "x": 0,
-        "y": 5
+        "y": 4
       },
       "id": 5,
       "options": {
@@ -434,7 +441,9 @@
               "mode": "off"
             }
           },
-          "unit": "reqps"
+          "decimals": 0,
+          "unit": "none",
+          "min": 0
         },
         "overrides": [
           {
@@ -464,10 +473,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 12,
         "x": 12,
-        "y": 5
+        "y": 4
       },
       "id": 6,
       "options": {
@@ -536,7 +545,10 @@
               "mode": "off"
             }
           },
-          "unit": "percentunit"
+          "decimals": 1,
+          "unit": "percentunit",
+          "min": 0,
+          "max": 0.25
         },
         "overrides": [
           {
@@ -566,10 +578,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 12,
         "x": 0,
-        "y": 13
+        "y": 10
       },
       "id": 7,
       "options": {
@@ -645,7 +657,9 @@
               "mode": "off"
             }
           },
-          "unit": "bytes"
+          "decimals": 1,
+          "unit": "bytes",
+          "min": 0
         },
         "overrides": [
           {
@@ -691,10 +705,10 @@
         ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 12,
         "x": 12,
-        "y": 13
+        "y": 10
       },
       "id": 8,
       "options": {
@@ -748,6 +762,6 @@
   "timezone": "",
   "title": "Fase 1 - Technical Monitoring",
   "uid": "fase1-technical-monitoring",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary
- Restore the Grafana dashboard JSON to the preferred layout from `90bee5e`.
- Keep the dashboard provisioning fix already in place.
- Bump the dashboard version to `3` so Grafana reprocesses it.

## Validation
- `jq empty grafana/dashboards/fase1-technical-monitoring.json`
- Confirmed P95 latency is a gauge in ms
- Confirmed request panels use req/min / numeric endpoint axis
- Confirmed compact panel layout is restored
