### PR TITLE
feat: expose all endpoints in docs and add API key auth to Swagger UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.worktrees/

--- a/app/health.py
+++ b/app/health.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter
 
 
-router = APIRouter(include_in_schema=False)
+router = APIRouter(tags=["health"])
 
 
 @router.get("/healthz")

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ app.include_router(monitoring_router)
 
 
 def custom_openapi() -> dict:
+    """Return OpenAPI schema extended with X-API-Key security scheme."""
     if app.openapi_schema:
         return app.openapi_schema
     schema = get_openapi(

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
 
 from app.forecast import router as forecast_router
 from app.health import router as health_router
@@ -22,3 +23,27 @@ app.include_router(wells_router)
 app.include_router(forecast_router)
 app.include_router(health_router)
 app.include_router(monitoring_router)
+
+
+def custom_openapi() -> dict:
+    if app.openapi_schema:
+        return app.openapi_schema
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        routes=app.routes,
+    )
+    schema.setdefault("components", {})
+    schema["components"]["securitySchemes"] = {
+        "ApiKeyAuth": {
+            "type": "apiKey",
+            "in": "header",
+            "name": "X-API-Key",
+        }
+    }
+    schema["security"] = [{"ApiKeyAuth": []}]
+    app.openapi_schema = schema
+    return schema
+
+
+app.openapi = custom_openapi  # type: ignore[method-assign]

--- a/app/monitoring.py
+++ b/app/monitoring.py
@@ -57,7 +57,7 @@ _REQUEST_DURATION_BUCKET_COUNTS: dict[MetricLabels, list[float]] = defaultdict(
 _LOCK = threading.Lock()
 _PROCESS_START_TIME_SECONDS = time()
 
-router = APIRouter(include_in_schema=False)
+router = APIRouter(tags=["monitoring"])
 
 
 def start_timer() -> float:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -36,9 +36,9 @@ def test_healthz_is_exposed_without_api_key() -> None:
     assert response.json() == {"status": "ok"}
 
 
-def test_healthz_is_hidden_from_openapi_schema() -> None:
-    """It should keep the technical health check out of the public schema."""
+def test_healthz_is_in_openapi_schema() -> None:
+    """Health check endpoint should be visible in the public schema."""
     response = client.get("/openapi.json")
 
     assert response.status_code == 200
-    assert "/healthz" not in response.json()["paths"]
+    assert "/healthz" in response.json()["paths"]


### PR DESCRIPTION
## Summary
- Los endpoints `/healthz` y `/metrics` ahora aparecen en `/docs` (se eliminó `include_in_schema=False` de los routers de health y monitoring)
- Se agregó un security scheme `ApiKeyAuth` global vía `custom_openapi()` en `main.py`, habilitando el botón **Authorize** en Swagger UI para ingresar el `X-API-Key`
- Se actualizó el test que verificaba que `/healthz` estaba oculto del schema

## Test Plan
- [ ] Abrir `/docs` y verificar que aparecen los 4 endpoints (wells, forecast, healthz, metrics)
- [ ] Hacer clic en **Authorize**, ingresar la API key y confirmar que las llamadas devuelven 200
- [ ] Sin API key, confirmar que devuelve `403 Invalid or missing API key`
- [ ] `uv run pytest` — 26 tests pasan

🤖 Generated with [Claude Code](https://claude.com/claude-code)