### PR TITLE
feat: add bronze data extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,49 @@ jobs:
       - name: Run tests with coverage
         run: uv run pytest --cov=app --cov-report=term-missing
 
+  data-extraction-test:
+    runs-on: ubuntu-latest
+
+    services:
+      warehouse:
+        image: postgres:16
+        env:
+          POSTGRES_USER: warehouse
+          POSTGRES_PASSWORD: warehouse
+          POSTGRES_DB: warehouse
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U warehouse"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      TEST_WAREHOUSE_HOST: localhost
+      TEST_WAREHOUSE_PORT: "5433"
+      TEST_WAREHOUSE_USER: warehouse
+      TEST_WAREHOUSE_PASSWORD: warehouse
+      TEST_WAREHOUSE_DB: warehouse
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install data dependencies
+        run: uv sync --group data
+
+      - name: Run bronze extraction tests
+        run: uv run --group data pytest tests/test_extraction_clients.py tests/test_extraction_idempotency.py tests/test_bronze_schema.py
+
   scan:
     runs-on: ubuntu-latest
     needs: []

--- a/Dockerfile.dagster
+++ b/Dockerfile.dagster
@@ -4,11 +4,13 @@ ENV DAGSTER_HOME=/opt/dagster/dagster_home
 RUN mkdir -p $DAGSTER_HOME
 
 WORKDIR /opt/dagster/app
+ENV PATH="/opt/dagster/app/.venv/bin:${PATH}"
 
 RUN pip install uv --no-cache-dir
 
 COPY pyproject.toml uv.lock ./
 RUN uv sync --group data --no-dev --frozen
+RUN dagster-webserver --help >/dev/null && dagster-daemon --help >/dev/null
 
 COPY workspace.yaml ./
 COPY data_platform/ ./data_platform/

--- a/data_platform/extraction/bronze_loader.py
+++ b/data_platform/extraction/bronze_loader.py
@@ -1,0 +1,148 @@
+"""Transactional PostgreSQL loader for bronze raw tables."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+from typing import Any
+
+from psycopg2 import sql
+from psycopg2.extensions import connection as PgConnection
+from psycopg2.extras import execute_values
+
+
+BRONZE_SCHEMA = "bronze"
+TECHNICAL_COLUMNS = (
+    "_load_period",
+    "_loaded_at",
+    "_source_url",
+    "_resource_id",
+    "_row_hash",
+)
+_IDENTIFIER_PATTERN = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class BronzeLoad:
+    """Payload for loading one raw CSV resource into bronze."""
+
+    table_name: str
+    load_period: str
+    source_url: str
+    resource_id: str
+    rows: Sequence[Mapping[str, str]]
+
+
+def load_bronze_table(conn: PgConnection, bronze_load: BronzeLoad) -> int:
+    """Replace one load-period partition in a bronze table."""
+    _validate_identifier(bronze_load.table_name)
+    source_columns = _source_columns(bronze_load.rows)
+    loaded_at = datetime.now(timezone.utc)
+
+    with conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                    sql.Identifier(BRONZE_SCHEMA)
+                )
+            )
+            _ensure_table(cursor, bronze_load.table_name, source_columns)
+            cursor.execute(
+                sql.SQL("DELETE FROM {}.{} WHERE _load_period = %s").format(
+                    sql.Identifier(BRONZE_SCHEMA),
+                    sql.Identifier(bronze_load.table_name),
+                ),
+                (bronze_load.load_period,),
+            )
+            if not bronze_load.rows:
+                return 0
+
+            all_columns = [*source_columns, *TECHNICAL_COLUMNS]
+            values = [
+                _row_values(row, source_columns, bronze_load, loaded_at)
+                for row in bronze_load.rows
+            ]
+            insert_query = sql.SQL("INSERT INTO {}.{} ({}) VALUES %s").format(
+                sql.Identifier(BRONZE_SCHEMA),
+                sql.Identifier(bronze_load.table_name),
+                sql.SQL(", ").join(sql.Identifier(column) for column in all_columns),
+            )
+            execute_values(cursor, insert_query, values)
+
+    return len(bronze_load.rows)
+
+
+def _ensure_table(
+    cursor: Any,
+    table_name: str,
+    source_columns: Sequence[str],
+) -> None:
+    column_defs = [
+        *[
+            sql.SQL("{} TEXT").format(sql.Identifier(column))
+            for column in source_columns
+        ],
+        sql.SQL("_load_period TEXT NOT NULL"),
+        sql.SQL("_loaded_at TIMESTAMPTZ NOT NULL"),
+        sql.SQL("_source_url TEXT NOT NULL"),
+        sql.SQL("_resource_id TEXT NOT NULL"),
+        sql.SQL("_row_hash TEXT NOT NULL"),
+    ]
+    cursor.execute(
+        sql.SQL("CREATE TABLE IF NOT EXISTS {}.{} ({})").format(
+            sql.Identifier(BRONZE_SCHEMA),
+            sql.Identifier(table_name),
+            sql.SQL(", ").join(column_defs),
+        )
+    )
+    for column in source_columns:
+        cursor.execute(
+            sql.SQL("ALTER TABLE {}.{} ADD COLUMN IF NOT EXISTS {} TEXT").format(
+                sql.Identifier(BRONZE_SCHEMA),
+                sql.Identifier(table_name),
+                sql.Identifier(column),
+            )
+        )
+
+
+def _source_columns(rows: Sequence[Mapping[str, str]]) -> list[str]:
+    columns: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        for column in row:
+            _validate_identifier(column)
+            if column not in seen:
+                seen.add(column)
+                columns.append(column)
+    return columns
+
+
+def _row_values(
+    row: Mapping[str, str],
+    source_columns: Sequence[str],
+    bronze_load: BronzeLoad,
+    loaded_at: datetime,
+) -> tuple[object, ...]:
+    source_values = [row.get(column, "") for column in source_columns]
+    return (
+        *source_values,
+        bronze_load.load_period,
+        loaded_at,
+        bronze_load.source_url,
+        bronze_load.resource_id,
+        _row_hash(row),
+    )
+
+
+def _row_hash(row: Mapping[str, str]) -> str:
+    encoded = json.dumps(row, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _validate_identifier(identifier: str) -> None:
+    if not _IDENTIFIER_PATTERN.match(identifier):
+        raise ValueError(f"Invalid PostgreSQL identifier: {identifier}")

--- a/data_platform/extraction/client.py
+++ b/data_platform/extraction/client.py
@@ -1,0 +1,88 @@
+"""Shared CSV download helpers for datos.gob.ar resources."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import csv
+from dataclasses import dataclass
+import io
+
+import httpx
+
+
+@dataclass(frozen=True)
+class CsvResource:
+    """Metadata required to download and trace a CSV resource."""
+
+    name: str
+    url: str
+    resource_id: str
+
+
+class ExtractionError(RuntimeError):
+    """Raised when a source resource cannot be downloaded or parsed."""
+
+
+def download_csv_rows(
+    resource: CsvResource,
+    *,
+    timeout_seconds: float = 30.0,
+    max_attempts: int = 3,
+    transport: httpx.BaseTransport | None = None,
+) -> list[dict[str, str]]:
+    """Download a CSV resource and return rows keyed by normalized headers."""
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+
+    last_error: Exception | None = None
+    for _attempt in range(1, max_attempts + 1):
+        try:
+            if transport is None:
+                client = httpx.Client(
+                    follow_redirects=True,
+                    timeout=timeout_seconds,
+                )
+            else:
+                client = httpx.Client(
+                    follow_redirects=True,
+                    timeout=timeout_seconds,
+                    transport=transport,
+                )
+            with client:
+                response = client.get(resource.url)
+                response.raise_for_status()
+                return _parse_csv_response(response.content)
+        except (httpx.HTTPError, csv.Error, UnicodeDecodeError) as exc:
+            last_error = exc
+
+    message = f"Failed to download {resource.name} from {resource.url}"
+    raise ExtractionError(message) from last_error
+
+
+def _parse_csv_response(content: bytes) -> list[dict[str, str]]:
+    """Parse UTF-8 CSV content, stripping BOM from the first header."""
+    text = content.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    if not reader.fieldnames:
+        raise ExtractionError("CSV response does not include a header row")
+
+    fieldnames = [_normalize_header(header) for header in reader.fieldnames]
+    rows: list[dict[str, str]] = []
+    for raw_row in reader:
+        rows.append(_normalize_row(raw_row, fieldnames))
+    return rows
+
+
+def _normalize_header(header: str) -> str:
+    return header.lstrip("\ufeff").strip()
+
+
+def _normalize_row(
+    raw_row: Mapping[str, str | None],
+    fieldnames: list[str],
+) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for original_key, normalized_key in zip(raw_row.keys(), fieldnames):
+        value = raw_row[original_key]
+        normalized[normalized_key] = "" if value is None else value
+    return normalized

--- a/data_platform/extraction/pozos.py
+++ b/data_platform/extraction/pozos.py
@@ -1,0 +1,26 @@
+"""Extraction client for the operator-submitted well list."""
+
+from __future__ import annotations
+
+import os
+
+from data_platform.extraction.client import CsvResource, download_csv_rows
+
+
+POZOS_RESOURCE_ID = "energia_cbfa4d79-ffb3-4096-bab5-eb0dde9a8385"
+POZOS_DEFAULT_URL = (
+    "http://datos.energia.gob.ar/dataset/c846e79c-026c-4040-897f-"
+    "1ad3543b407c/resource/cbfa4d79-ffb3-4096-bab5-eb0dde9a8385/download/"
+    "listado-de-pozos-cargados-por-empresas-operadoras.csv"
+)
+POZOS_URL_ENV = "POZOS_OPERADORAS_URL"
+
+
+def fetch_pozos_rows() -> list[dict[str, str]]:
+    """Download raw operator-submitted well rows."""
+    resource = CsvResource(
+        name="pozos",
+        url=os.getenv(POZOS_URL_ENV, POZOS_DEFAULT_URL),
+        resource_id=POZOS_RESOURCE_ID,
+    )
+    return download_csv_rows(resource)

--- a/data_platform/extraction/produccion.py
+++ b/data_platform/extraction/produccion.py
@@ -1,0 +1,26 @@
+"""Extraction client for non-conventional well production."""
+
+from __future__ import annotations
+
+import os
+
+from data_platform.extraction.client import CsvResource, download_csv_rows
+
+
+PRODUCCION_RESOURCE_ID = "energia_b5b58cdc-9e07-41f9-b392-fb9ec68b0725"
+PRODUCCION_DEFAULT_URL = (
+    "http://datos.energia.gob.ar/dataset/c846e79c-026c-4040-897f-"
+    "1ad3543b407c/resource/b5b58cdc-9e07-41f9-b392-fb9ec68b0725/download/"
+    "produccin-de-pozos-de-gas-y-petrleo-no-convencional.csv"
+)
+PRODUCCION_URL_ENV = "PRODUCCION_NO_CONVENCIONAL_URL"
+
+
+def fetch_produccion_rows() -> list[dict[str, str]]:
+    """Download raw non-conventional production rows."""
+    resource = CsvResource(
+        name="produccion",
+        url=os.getenv(PRODUCCION_URL_ENV, PRODUCCION_DEFAULT_URL),
+        resource_id=PRODUCCION_RESOURCE_ID,
+    )
+    return download_csv_rows(resource)

--- a/data_platform/orchestration/__init__.py
+++ b/data_platform/orchestration/__init__.py
@@ -1,3 +1,5 @@
 from dagster import Definitions
 
-defs = Definitions()
+from data_platform.orchestration.assets.bronze import bronze_assets
+
+defs = Definitions(assets=bronze_assets)

--- a/data_platform/orchestration/__init__.py
+++ b/data_platform/orchestration/__init__.py
@@ -1,3 +1,5 @@
+"""Dagster definitions for the data platform."""
+
 from dagster import Definitions
 
 from data_platform.orchestration.assets.bronze import bronze_assets

--- a/data_platform/orchestration/assets/bronze.py
+++ b/data_platform/orchestration/assets/bronze.py
@@ -1,0 +1,83 @@
+"""Dagster assets that land datos.gob.ar resources into bronze."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import os
+
+from dagster import AssetExecutionContext, MonthlyPartitionsDefinition, asset
+import psycopg2
+from psycopg2.extensions import connection as PgConnection
+
+from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
+from data_platform.extraction.pozos import (
+    POZOS_DEFAULT_URL,
+    POZOS_RESOURCE_ID,
+    POZOS_URL_ENV,
+    fetch_pozos_rows,
+)
+from data_platform.extraction.produccion import (
+    PRODUCCION_DEFAULT_URL,
+    PRODUCCION_RESOURCE_ID,
+    PRODUCCION_URL_ENV,
+    fetch_produccion_rows,
+)
+
+
+bronze_monthly_partitions = MonthlyPartitionsDefinition(start_date="2026-01-01")
+
+
+@asset(partitions_def=bronze_monthly_partitions, group_name="bronze")
+def bronze_produccion_raw(context: AssetExecutionContext) -> int:
+    """Load raw non-conventional production rows into bronze.produccion_raw."""
+    rows = fetch_produccion_rows()
+    with warehouse_connection() as conn:
+        row_count = load_bronze_table(
+            conn,
+            BronzeLoad(
+                table_name="produccion_raw",
+                load_period=context.partition_key,
+                source_url=os.getenv(PRODUCCION_URL_ENV, PRODUCCION_DEFAULT_URL),
+                resource_id=PRODUCCION_RESOURCE_ID,
+                rows=rows,
+            ),
+        )
+    context.log.info("Loaded %s rows into bronze.produccion_raw", row_count)
+    return row_count
+
+
+@asset(partitions_def=bronze_monthly_partitions, group_name="bronze")
+def bronze_pozos_raw(context: AssetExecutionContext) -> int:
+    """Load raw operator-submitted well rows into bronze.pozos_raw."""
+    rows = fetch_pozos_rows()
+    with warehouse_connection() as conn:
+        row_count = load_bronze_table(
+            conn,
+            BronzeLoad(
+                table_name="pozos_raw",
+                load_period=context.partition_key,
+                source_url=os.getenv(POZOS_URL_ENV, POZOS_DEFAULT_URL),
+                resource_id=POZOS_RESOURCE_ID,
+                rows=rows,
+            ),
+        )
+    context.log.info("Loaded %s rows into bronze.pozos_raw", row_count)
+    return row_count
+
+
+@contextmanager
+def warehouse_connection() -> Iterator[PgConnection]:
+    """Open a PostgreSQL warehouse connection from environment variables."""
+    conn = psycopg2.connect(
+        host=os.getenv("WAREHOUSE_HOST", "localhost"),
+        port=int(os.getenv("WAREHOUSE_PORT", "5433")),
+        user=os.getenv("WAREHOUSE_USER", "warehouse"),
+        password=os.getenv("WAREHOUSE_PASSWORD", "warehouse"),
+        dbname=os.getenv("WAREHOUSE_DB", "warehouse"),
+    )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+bronze_assets = [bronze_produccion_raw, bronze_pozos_raw]

--- a/data_platform/transform/models/sources.yml
+++ b/data_platform/transform/models/sources.yml
@@ -6,14 +6,14 @@ sources:
     schema: bronze
     tables:
       - name: produccion_raw
-        description: "Producción mensual de pozos no convencionales (placeholder — PR2)"
+        description: "Producción mensual cruda de pozos de gas y petróleo no convencional, cargada desde datos.gob.ar sin tipado de negocio."
         loaded_at_field: _loaded_at
         freshness:
           warn_after: {count: 35, period: day}
           error_after: {count: 60, period: day}
 
       - name: pozos_raw
-        description: "Listado de pozos por operadora (placeholder — PR2)"
+        description: "Listado crudo de pozos cargados por empresas operadoras, cargado desde datos.gob.ar sin tipado de negocio."
         loaded_at_field: _loaded_at
         freshness:
           warn_after: {count: 35, period: day}

--- a/docs/ADRs/12-medallion-layering.md
+++ b/docs/ADRs/12-medallion-layering.md
@@ -1,0 +1,52 @@
+# ADR-12: Capas medallion para la plataforma de datos
+
+```
+status: Aceptado
+date: 2026-06-09
+decision-makers: Equipo de Desarrollo
+```
+
+## Contexto y declaración del problema
+
+La Fase 2 necesita ordenar el flujo de datos reales de producción de hidrocarburos desde
+datos.gob.ar hasta modelos consumibles por BI y gobierno. La decisión central es dónde
+preservar datos crudos, dónde limpiar/tipar y dónde publicar entidades analíticas.
+
+## Impulsores de la decisión
+
+* Mantener trazabilidad hacia los CSV oficiales.
+* Permitir reprocesos idempotentes por período de carga.
+* Separar ingestión cruda de reglas de negocio.
+* Facilitar tests de calidad y lineage con dbt.
+
+## Opciones consideradas
+
+* **Una sola capa transformada** — cargar directo a tablas analíticas.
+* **Dos capas raw + curated** — preservar crudo y publicar modelos limpios.
+* **Medallion bronze/silver/gold** — raw, staging conformado y modelo dimensional.
+
+## Resultado de la decisión
+
+Opción elegida: **medallion bronze/silver/gold**.
+
+La capa **bronze** conserva todas las columnas de los CSV como texto y agrega solo
+metadata técnica de carga: `_load_period`, `_loaded_at`, `_source_url`, `_resource_id` y
+`_row_hash`. No castea fechas, números ni categorías de negocio. La capa **silver** queda
+responsable de tipar, limpiar, deduplicar y conformar datos. La capa **gold** queda
+responsable del modelo estrella y las métricas consumibles.
+
+## Consecuencias
+
+* Bueno, porque un cambio en reglas de negocio se resuelve reprocesando silver/gold sin
+  volver a descargar la fuente.
+* Bueno, porque bronze permite auditar qué recurso y período de carga produjo cada fila.
+* Bueno, porque dbt puede declarar fuentes sobre bronze y exponer freshness desde
+  `_loaded_at`.
+* Malo, porque bronze no es cómodo para análisis directo: todo llega como texto.
+
+## Confirmación
+
+Confirmado en `data_platform/extraction/bronze_loader.py`: la carga crea tablas en el
+schema `bronze`, reemplaza idempotentemente por `_load_period` y agrega metadata técnica.
+Confirmado en `data_platform/transform/models/sources.yml`: dbt declara
+`bronze.produccion_raw` y `bronze.pozos_raw` con `loaded_at_field: _loaded_at`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,15 @@
 """Global test configuration and fixtures."""
 
 from collections.abc import Iterator
-import importlib.util
 import os
 from typing import Any
 
 import pytest
+
+try:
+    import psycopg2
+except ImportError:
+    psycopg2 = None
 
 from app.alerts import AlertConfig, MockNotifier
 
@@ -29,10 +33,8 @@ def alert_config() -> AlertConfig:
 
 
 def _connect_to_test_warehouse() -> Any:
-    if importlib.util.find_spec("psycopg2") is None:
+    if psycopg2 is None:
         pytest.skip("psycopg2 is not installed")
-
-    import psycopg2
 
     return psycopg2.connect(
         host=os.getenv("TEST_WAREHOUSE_HOST", os.getenv("WAREHOUSE_HOST", "localhost")),
@@ -48,10 +50,8 @@ def _connect_to_test_warehouse() -> Any:
 @pytest.fixture
 def warehouse_connection() -> Iterator[Any]:
     """Provide a PostgreSQL connection for bronze integration tests."""
-    if importlib.util.find_spec("psycopg2") is None:
+    if psycopg2 is None:
         pytest.skip("psycopg2 is not installed")
-
-    import psycopg2
 
     try:
         conn = _connect_to_test_warehouse()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 """Global test configuration and fixtures."""
 
+from collections.abc import Iterator
+import importlib.util
 import os
+from typing import Any
 
 import pytest
 
@@ -23,3 +26,39 @@ def alert_config() -> AlertConfig:
         error_rate_threshold=0.05,
         service_down_threshold=30,
     )
+
+
+def _connect_to_test_warehouse() -> Any:
+    if importlib.util.find_spec("psycopg2") is None:
+        pytest.skip("psycopg2 is not installed")
+
+    import psycopg2
+
+    return psycopg2.connect(
+        host=os.getenv("TEST_WAREHOUSE_HOST", os.getenv("WAREHOUSE_HOST", "localhost")),
+        port=int(os.getenv("TEST_WAREHOUSE_PORT", os.getenv("WAREHOUSE_PORT", "5433"))),
+        user=os.getenv("TEST_WAREHOUSE_USER", os.getenv("WAREHOUSE_USER", "warehouse")),
+        password=os.getenv(
+            "TEST_WAREHOUSE_PASSWORD", os.getenv("WAREHOUSE_PASSWORD", "warehouse")
+        ),
+        dbname=os.getenv("TEST_WAREHOUSE_DB", os.getenv("WAREHOUSE_DB", "warehouse")),
+    )
+
+
+@pytest.fixture
+def warehouse_connection() -> Iterator[Any]:
+    """Provide a PostgreSQL connection for bronze integration tests."""
+    if importlib.util.find_spec("psycopg2") is None:
+        pytest.skip("psycopg2 is not installed")
+
+    import psycopg2
+
+    try:
+        conn = _connect_to_test_warehouse()
+    except psycopg2.OperationalError as exc:
+        pytest.skip(f"PostgreSQL warehouse is not available: {exc}")
+
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/tests/test_bronze_schema.py
+++ b/tests/test_bronze_schema.py
@@ -2,13 +2,13 @@
 
 from typing import Any
 
+from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
+
 
 def test_produccion_raw_has_source_and_technical_columns(
     warehouse_connection: Any,
 ) -> None:
     """The production bronze table should include raw and load metadata columns."""
-    from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
-
     load_bronze_table(
         warehouse_connection,
         BronzeLoad(
@@ -61,8 +61,6 @@ def test_pozos_raw_has_source_and_technical_columns(
     warehouse_connection: Any,
 ) -> None:
     """The wells bronze table should include raw and load metadata columns."""
-    from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
-
     load_bronze_table(
         warehouse_connection,
         BronzeLoad(

--- a/tests/test_bronze_schema.py
+++ b/tests/test_bronze_schema.py
@@ -1,0 +1,107 @@
+"""Integration tests for bronze table schemas."""
+
+from typing import Any
+
+
+def test_produccion_raw_has_source_and_technical_columns(
+    warehouse_connection: Any,
+) -> None:
+    """The production bronze table should include raw and load metadata columns."""
+    from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
+
+    load_bronze_table(
+        warehouse_connection,
+        BronzeLoad(
+            table_name="produccion_raw",
+            load_period="2026-07",
+            source_url="https://example.test/produccion.csv",
+            resource_id="resource-produccion",
+            rows=[
+                {
+                    "idempresa": "YSUR",
+                    "anio": "2016",
+                    "mes": "1",
+                    "idpozo": "135204",
+                    "prod_pet": "0.000",
+                    "prod_gas": "59.940",
+                    "fecha_data": "2016-01-31",
+                }
+            ],
+        ),
+    )
+
+    with warehouse_connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'bronze'
+              AND table_name = 'produccion_raw'
+            """
+        )
+        columns = {row[0] for row in cursor.fetchall()}
+
+    assert {
+        "idempresa",
+        "anio",
+        "mes",
+        "idpozo",
+        "prod_pet",
+        "prod_gas",
+        "fecha_data",
+        "_load_period",
+        "_loaded_at",
+        "_source_url",
+        "_resource_id",
+        "_row_hash",
+    }.issubset(columns)
+
+
+def test_pozos_raw_has_source_and_technical_columns(
+    warehouse_connection: Any,
+) -> None:
+    """The wells bronze table should include raw and load metadata columns."""
+    from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
+
+    load_bronze_table(
+        warehouse_connection,
+        BronzeLoad(
+            table_name="pozos_raw",
+            load_period="2026-07",
+            source_url="https://example.test/pozos.csv",
+            resource_id="resource-pozos",
+            rows=[
+                {
+                    "idpozo": "144081",
+                    "sigla": "315",
+                    "formprod": "FIMP",
+                    "idempresa": "APEA",
+                    "fecha_data": "",
+                }
+            ],
+        ),
+    )
+
+    with warehouse_connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'bronze'
+              AND table_name = 'pozos_raw'
+            """
+        )
+        columns = {row[0] for row in cursor.fetchall()}
+
+    assert {
+        "idpozo",
+        "sigla",
+        "formprod",
+        "idempresa",
+        "fecha_data",
+        "_load_period",
+        "_loaded_at",
+        "_source_url",
+        "_resource_id",
+        "_row_hash",
+    }.issubset(columns)

--- a/tests/test_bronze_schema.py
+++ b/tests/test_bronze_schema.py
@@ -1,8 +1,17 @@
 """Integration tests for bronze table schemas."""
 
+# pylint: disable=wrong-import-position
+
 from typing import Any
 
-from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
+import pytest
+
+pytest.importorskip("psycopg2")
+
+from data_platform.extraction.bronze_loader import (  # noqa: E402
+    BronzeLoad,
+    load_bronze_table,
+)
 
 
 def test_produccion_raw_has_source_and_technical_columns(

--- a/tests/test_extraction_clients.py
+++ b/tests/test_extraction_clients.py
@@ -1,0 +1,65 @@
+"""Tests for datos.gob.ar extraction clients."""
+
+import httpx
+import pytest
+
+from data_platform.extraction.client import (
+    CsvResource,
+    ExtractionError,
+    download_csv_rows,
+)
+
+
+def test_download_csv_rows_normalizes_bom_in_headers() -> None:
+    """It should strip a UTF-8 BOM from the first CSV header."""
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            200,
+            content=(
+                "\ufeffidpozo,sigla,empresa\n"
+                "135204,APA.Nq.ACO-13(d),YSUR ENERGIA ARGENTINA S.R.L.\n"
+            ).encode("utf-8"),
+        )
+    )
+
+    rows = download_csv_rows(
+        CsvResource(
+            name="pozos",
+            url="https://example.test/pozos.csv",
+            resource_id="resource-pozos",
+        ),
+        transport=transport,
+    )
+
+    assert rows == [
+        {
+            "idpozo": "135204",
+            "sigla": "APA.Nq.ACO-13(d)",
+            "empresa": "YSUR ENERGIA ARGENTINA S.R.L.",
+        }
+    ]
+
+
+def test_download_csv_rows_raises_clear_error_after_retries() -> None:
+    """It should retry failed requests and raise an extraction error."""
+    attempts = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(503, text="temporarily unavailable")
+
+    transport = httpx.MockTransport(handler)
+
+    with pytest.raises(ExtractionError, match="Failed to download produccion"):
+        download_csv_rows(
+            CsvResource(
+                name="produccion",
+                url="https://example.test/produccion.csv",
+                resource_id="resource-produccion",
+            ),
+            max_attempts=3,
+            transport=transport,
+        )
+
+    assert attempts == 3

--- a/tests/test_extraction_idempotency.py
+++ b/tests/test_extraction_idempotency.py
@@ -2,13 +2,13 @@
 
 from typing import Any
 
+from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
+
 
 def test_load_bronze_table_replaces_existing_partition(
     warehouse_connection: Any,
 ) -> None:
     """Running the same partition twice should not duplicate rows."""
-    from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
-
     first_load = BronzeLoad(
         table_name="produccion_raw",
         load_period="2026-06",

--- a/tests/test_extraction_idempotency.py
+++ b/tests/test_extraction_idempotency.py
@@ -1,8 +1,17 @@
 """Integration tests for idempotent bronze loading."""
 
+# pylint: disable=wrong-import-position
+
 from typing import Any
 
-from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
+import pytest
+
+pytest.importorskip("psycopg2")
+
+from data_platform.extraction.bronze_loader import (  # noqa: E402
+    BronzeLoad,
+    load_bronze_table,
+)
 
 
 def test_load_bronze_table_replaces_existing_partition(

--- a/tests/test_extraction_idempotency.py
+++ b/tests/test_extraction_idempotency.py
@@ -1,0 +1,47 @@
+"""Integration tests for idempotent bronze loading."""
+
+from typing import Any
+
+
+def test_load_bronze_table_replaces_existing_partition(
+    warehouse_connection: Any,
+) -> None:
+    """Running the same partition twice should not duplicate rows."""
+    from data_platform.extraction.bronze_loader import BronzeLoad, load_bronze_table
+
+    first_load = BronzeLoad(
+        table_name="produccion_raw",
+        load_period="2026-06",
+        source_url="https://example.test/produccion.csv",
+        resource_id="resource-produccion",
+        rows=[
+            {"idempresa": "YSUR", "anio": "2016", "mes": "1", "idpozo": "135204"},
+            {"idempresa": "YPF", "anio": "2016", "mes": "1", "idpozo": "155584"},
+        ],
+    )
+    second_load = BronzeLoad(
+        table_name="produccion_raw",
+        load_period="2026-06",
+        source_url="https://example.test/produccion.csv",
+        resource_id="resource-produccion",
+        rows=[
+            {"idempresa": "PAMPA", "anio": "2016", "mes": "1", "idpozo": "200001"},
+        ],
+    )
+
+    load_bronze_table(warehouse_connection, first_load)
+    load_bronze_table(warehouse_connection, second_load)
+
+    with warehouse_connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COUNT(*), MIN(idempresa)
+            FROM bronze.produccion_raw
+            WHERE _load_period = %s
+            """,
+            ("2026-06",),
+        )
+        row_count, only_company = cursor.fetchone()
+
+    assert row_count == 1
+    assert only_company == "PAMPA"


### PR DESCRIPTION
## Summary

Adds PR 2 of the Phase 2 data platform plan: bronze ingestion for the two official datos.gob.ar CSV resources.

This PR downloads the official production and wells CSVs, loads them idempotently into PostgreSQL bronze raw tables, exposes them as dbt sources, and adds CI coverage for the extraction layer with a real Postgres service.

## Changes

- Added extraction clients for:
  - Produccion de Pozos de Gas y Petroleo No Convencional
  - Listado de pozos cargados por empresas operadoras
- Added shared bronze loader:
  - Creates `bronze.produccion_raw` and `bronze.pozos_raw`
  - Stores source CSV fields as `TEXT`
  - Adds `_load_period`, `_loaded_at`, `_source_url`, `_resource_id`, `_row_hash`
  - Replaces rows idempotently per `_load_period`
- Added Dagster bronze assets:
  - `bronze_produccion_raw`
  - `bronze_pozos_raw`
- Updated dbt bronze source declarations.
- Added ADR 12 for medallion layering.
- Added Postgres-backed integration tests for schema and idempotency.
- Added CI `data-extraction-test` job with Postgres 16.
- Fixed Docker Dagster startup by adding the uv-created virtualenv to `PATH`.
- Ensured default test job skips bronze DB tests when data dependencies are not installed.

## Verification

- `uv run pre-commit run --all-files`
- `uv run pytest --cov=app --cov-report=term-missing`
- `uv run --group data pytest tests/test_extraction_clients.py tests/test_extraction_idempotency.py tests/test_bronze_schema.py`
- `uv run --group data dagster definitions validate -m data_platform.orchestration`
- `uv run --group data dbt parse --project-dir data_platform/transform --profiles-dir data_platform/transform`

CI is passing for:
- lint
- test
- data-extraction-test
- scan
- dbt-parse
- dagster-validate