### PR TITLE
feat: BI con Metabase sobre la capa gold

### DIFF
--- a/.env.data.example
+++ b/.env.data.example
@@ -18,6 +18,9 @@ METABASE_DB_PASSWORD=metabase
 METABASE_DB_NAME=metabase
 METABASE_PORT=3002
 
+# Metabase encryption key — set to a random secret in production
+MB_ENCRYPTION_SECRET_KEY=change-me-random-secret
+
 # Metabase provisioning (data_platform.bi.provision) — bootstrap admin + API target
 METABASE_URL=http://localhost:3002
 METABASE_ADMIN_EMAIL=admin@example.com
@@ -27,3 +30,8 @@ METABASE_ADMIN_LAST_NAME=Admin
 # Hostname/port the Metabase container uses to reach the warehouse (container network)
 METABASE_WAREHOUSE_HOST=warehouse
 METABASE_WAREHOUSE_PORT=5432
+# Read-only Postgres role for the Metabase→warehouse connection.
+# Create it with: CREATE ROLE metabase_ro LOGIN PASSWORD '...';
+#                 GRANT SELECT ON ALL TABLES IN SCHEMA gold TO metabase_ro;
+METABASE_WAREHOUSE_USER=metabase_ro
+METABASE_WAREHOUSE_PASSWORD=change-me

--- a/.env.data.example
+++ b/.env.data.example
@@ -11,3 +11,19 @@ DBT_WAREHOUSE_PORT=5433
 DBT_WAREHOUSE_USER=warehouse
 DBT_WAREHOUSE_PASSWORD=warehouse
 DBT_WAREHOUSE_DB=warehouse
+
+# Metabase application metadata (its own Postgres, not the warehouse)
+METABASE_DB_USER=metabase
+METABASE_DB_PASSWORD=metabase
+METABASE_DB_NAME=metabase
+METABASE_PORT=3002
+
+# Metabase provisioning (data_platform.bi.provision) — bootstrap admin + API target
+METABASE_URL=http://localhost:3002
+METABASE_ADMIN_EMAIL=admin@example.com
+METABASE_ADMIN_PASSWORD=metabase123
+METABASE_ADMIN_FIRST_NAME=Data
+METABASE_ADMIN_LAST_NAME=Admin
+# Hostname/port the Metabase container uses to reach the warehouse (container network)
+METABASE_WAREHOUSE_HOST=warehouse
+METABASE_WAREHOUSE_PORT=5432

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,3 +220,6 @@ jobs:
 
       - name: Run data quality tests
         run: uv run --group data pytest tests/test_quality_persistence.py
+
+      - name: Validate Metabase card SQL against gold
+        run: uv run --group data pytest tests/test_metabase_cards_sql.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,4 @@ repos:
           - fastapi
           - pydantic
           - httpx
+          - types-requests

--- a/README.md
+++ b/README.md
@@ -42,6 +42,33 @@ Servicios: API `:8000` · Prometheus `:9090` · Grafana `:3000`
 
 Credenciales de Grafana: usuario `admin`, contraseña = `GF_SECURITY_ADMIN_PASSWORD` en `.env`.
 
+## Plataforma de BI (Metabase)
+
+La capa gold se expone a usuarios no tecnicos con [Metabase](https://www.metabase.com/),
+conectado al esquema `gold` del warehouse. La decision se documenta en
+[ADR-18](docs/ADRs/18-bi-tool.md).
+
+```bash
+cp .env.data.example .env.data        # ajustar credenciales si hace falta
+docker compose --env-file .env.data -f docker-compose.data.yml up -d
+
+# Esperar a que Metabase este "healthy" (primer arranque tarda ~1 min)
+docker compose -f docker-compose.data.yml ps metabase
+
+# Aplicar conexion al warehouse + dashboards de forma idempotente
+uv run --group data python -m data_platform.bi.provision
+```
+
+Acceso: `http://localhost:3002` (usuario y contrasena = `METABASE_ADMIN_EMAIL` /
+`METABASE_ADMIN_PASSWORD` de `.env.data`).
+
+El provisioning es **reproducible y versionado**: las preguntas y el dashboard se definen
+en [`data_platform/bi/metabase_config.py`](data_platform/bi/metabase_config.py) y se
+aplican con [`data_platform/bi/provision.py`](data_platform/bi/provision.py). Re-ejecutar
+el comando converge al mismo estado sin duplicar. El dashboard "Produccion de pozos no
+convencionales" incluye produccion de gas por cuenca, petroleo por operadora, top pozos,
+evolucion mensual y la marca de calidad de los datos.
+
 ## Testing y calidad
 
 ```bash

--- a/data_platform/bi/__init__.py
+++ b/data_platform/bi/__init__.py
@@ -1,0 +1,1 @@
+"""Business intelligence layer: Metabase configuration and provisioning."""

--- a/data_platform/bi/metabase_config.py
+++ b/data_platform/bi/metabase_config.py
@@ -155,7 +155,7 @@ CARDS: tuple[Card, ...] = (
             "    failed_rows,\n"
             "    checked_at\n"
             "from gold.quality_marks\n"
-            "order by status desc, check_name"
+            "order by case when status = 'ERROR' then 0 else 1 end, check_name"
         ),
         display=DISPLAY_TABLE,
     ),

--- a/data_platform/bi/metabase_config.py
+++ b/data_platform/bi/metabase_config.py
@@ -1,0 +1,185 @@
+"""Declarative, version-controlled definition of the Metabase BI assets.
+
+This module is the reproducible "export" of the BI configuration: the warehouse
+connection target, the questions (cards) that non-technical users consume and the
+dashboard that groups them. It is pure data (standard library only) so it can be
+imported and validated without a running Metabase or warehouse.
+
+The companion module :mod:`data_platform.bi.provision` reads these definitions and
+applies them idempotently against the Metabase REST API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# All BI queries read exclusively from the gold layer of the warehouse.
+WAREHOUSE_SCHEMA = "gold"
+
+# Logical names used to make provisioning idempotent (lookups are by name).
+WAREHOUSE_DATABASE_NAME = "Warehouse (gold)"
+COLLECTION_NAME = "Plataforma de Datos - Pozos"
+
+# Valid Metabase visualization types used by this configuration.
+DISPLAY_LINE = "line"
+DISPLAY_BAR = "bar"
+DISPLAY_TABLE = "table"
+VALID_DISPLAYS = frozenset({DISPLAY_LINE, DISPLAY_BAR, DISPLAY_TABLE})
+
+
+@dataclass(frozen=True)
+class Card:
+    """A single Metabase question backed by a native SQL query over the gold layer."""
+
+    name: str
+    description: str
+    sql: str
+    display: str
+    dimensions: tuple[str, ...] = field(default_factory=tuple)
+    metrics: tuple[str, ...] = field(default_factory=tuple)
+
+    def visualization_settings(self) -> dict[str, list[str]]:
+        """Build Metabase ``visualization_settings`` for graph displays.
+
+        Tables need no axis mapping; line and bar charts map result columns to the
+        dimension (x axis / breakout) and metric (y axis) roles.
+        """
+        if self.display == DISPLAY_TABLE:
+            return {}
+        return {
+            "graph.dimensions": list(self.dimensions),
+            "graph.metrics": list(self.metrics),
+        }
+
+
+@dataclass(frozen=True)
+class Dashboard:
+    """A dashboard grouping a set of cards by name."""
+
+    name: str
+    description: str
+    card_names: tuple[str, ...]
+
+
+CARDS: tuple[Card, ...] = (
+    Card(
+        name="Producción de gas por cuenca",
+        description=(
+            "Gas producido por cuenca a lo largo del tiempo, para comparar la "
+            "evolución entre cuencas."
+        ),
+        sql=(
+            "select\n"
+            "    f.periodo as periodo,\n"
+            "    c.cuenca as cuenca,\n"
+            "    sum(f.prod_gas) as prod_gas\n"
+            "from gold.fct_produccion as f\n"
+            "join gold.dim_cuenca as c on f.cuenca_key = c.cuenca_key\n"
+            "group by f.periodo, c.cuenca\n"
+            "order by f.periodo, c.cuenca"
+        ),
+        display=DISPLAY_LINE,
+        dimensions=("periodo", "cuenca"),
+        metrics=("prod_gas",),
+    ),
+    Card(
+        name="Producción de petróleo por operadora",
+        description=(
+            "Petróleo producido por operadora a lo largo del tiempo, para ver el "
+            "aporte de cada empresa."
+        ),
+        sql=(
+            "select\n"
+            "    f.periodo as periodo,\n"
+            "    e.empresa as operadora,\n"
+            "    sum(f.prod_petroleo) as prod_petroleo\n"
+            "from gold.fct_produccion as f\n"
+            "join gold.dim_empresa as e on f.empresa_key = e.empresa_key\n"
+            "group by f.periodo, e.empresa\n"
+            "order by f.periodo, e.empresa"
+        ),
+        display=DISPLAY_LINE,
+        dimensions=("periodo", "operadora"),
+        metrics=("prod_petroleo",),
+    ),
+    Card(
+        name="Top pozos por producción acumulada",
+        description=(
+            "Los 20 pozos con mayor producción acumulada (gas + petróleo) en todo el "
+            "período disponible."
+        ),
+        sql=(
+            "select\n"
+            "    p.sigla as pozo,\n"
+            "    sum(f.prod_gas + f.prod_petroleo) as produccion_total\n"
+            "from gold.fct_produccion as f\n"
+            "join gold.dim_pozo as p on f.pozo_key = p.pozo_key\n"
+            "group by p.sigla\n"
+            "order by produccion_total desc\n"
+            "limit 20"
+        ),
+        display=DISPLAY_BAR,
+        dimensions=("pozo",),
+        metrics=("produccion_total",),
+    ),
+    Card(
+        name="Evolución mensual de producción total",
+        description=(
+            "Producción total mensual de gas, petróleo y agua sumando todos los pozos."
+        ),
+        sql=(
+            "select\n"
+            "    f.periodo as periodo,\n"
+            "    sum(f.prod_gas) as prod_gas,\n"
+            "    sum(f.prod_petroleo) as prod_petroleo,\n"
+            "    sum(f.prod_agua) as prod_agua\n"
+            "from gold.fct_produccion as f\n"
+            "group by f.periodo\n"
+            "order by f.periodo"
+        ),
+        display=DISPLAY_LINE,
+        dimensions=("periodo",),
+        metrics=("prod_gas", "prod_petroleo", "prod_agua"),
+    ),
+    Card(
+        name="Marca de calidad de los datos",
+        description=(
+            "Último estado de cada control de calidad sobre la capa gold. Revisar "
+            "antes de publicar: un check en ERROR indica datos no confiables."
+        ),
+        sql=(
+            "select\n"
+            "    check_name,\n"
+            "    dimension,\n"
+            "    status,\n"
+            "    failed_rows,\n"
+            "    checked_at\n"
+            "from gold.quality_marks\n"
+            "order by status desc, check_name"
+        ),
+        display=DISPLAY_TABLE,
+    ),
+)
+
+
+DASHBOARD = Dashboard(
+    name="Producción de pozos no convencionales",
+    description=(
+        "Vista para usuarios no técnicos: producción por cuenca y operadora, top "
+        "pozos, evolución mensual y la marca de calidad de los datos."
+    ),
+    card_names=tuple(card.name for card in CARDS),
+)
+
+
+def card_names() -> set[str]:
+    """Return the set of all configured card names."""
+    return {card.name for card in CARDS}
+
+
+def get_card(name: str) -> Card:
+    """Return the card with the given name, raising ``KeyError`` if missing."""
+    for card in CARDS:
+        if card.name == name:
+            return card
+    raise KeyError(name)

--- a/data_platform/bi/provision.py
+++ b/data_platform/bi/provision.py
@@ -13,7 +13,7 @@ Configuration is taken from environment variables (see ``.env.data.example``):
     METABASE_URL, METABASE_ADMIN_EMAIL, METABASE_ADMIN_PASSWORD,
     METABASE_ADMIN_FIRST_NAME, METABASE_ADMIN_LAST_NAME,
     METABASE_WAREHOUSE_HOST, METABASE_WAREHOUSE_PORT,
-    WAREHOUSE_DB, WAREHOUSE_USER, WAREHOUSE_PASSWORD.
+    WAREHOUSE_DB, METABASE_WAREHOUSE_USER, METABASE_WAREHOUSE_PASSWORD.
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 import os
 import sys
 import time
-from typing import Any
+from typing import Any, cast
 
 import requests
 
@@ -51,8 +51,8 @@ class MetabaseSettings:  # pylint: disable=too-many-instance-attributes
     warehouse_host: str
     warehouse_port: int
     warehouse_db: str
-    warehouse_user: str
-    warehouse_password: str
+    metabase_warehouse_user: str
+    metabase_warehouse_password: str
 
 
 def settings_from_env() -> MetabaseSettings:
@@ -66,8 +66,8 @@ def settings_from_env() -> MetabaseSettings:
         warehouse_host=os.getenv("METABASE_WAREHOUSE_HOST", "warehouse"),
         warehouse_port=int(os.getenv("METABASE_WAREHOUSE_PORT", "5432")),
         warehouse_db=os.getenv("WAREHOUSE_DB", "warehouse"),
-        warehouse_user=os.getenv("WAREHOUSE_USER", "warehouse"),
-        warehouse_password=os.getenv("WAREHOUSE_PASSWORD", "warehouse"),
+        metabase_warehouse_user=os.getenv("METABASE_WAREHOUSE_USER", "metabase_ro"),
+        metabase_warehouse_password=os.getenv("METABASE_WAREHOUSE_PASSWORD", ""),
     )
 
 
@@ -88,7 +88,9 @@ class MetabaseClient:
             headers["X-Metabase-Session"] = self._token
         return headers
 
-    def request(self, method: str, path: str, **kwargs: Any) -> Any:
+    def request(
+        self, method: str, path: str, **kwargs: Any
+    ) -> dict[str, Any] | list[Any] | None:
         """Issue an API request and return the parsed JSON body (or ``None``)."""
         response = self._session.request(
             method,
@@ -100,7 +102,12 @@ class MetabaseClient:
         response.raise_for_status()
         if not response.content:
             return None
-        return response.json()
+        return cast(dict[str, Any] | list[Any] | None, response.json())
+
+    def request_dict(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        """Like :meth:`request` but asserts the response is a JSON object."""
+        result = self.request(method, path, **kwargs)
+        return cast(dict[str, Any], result)
 
     def wait_until_healthy(self) -> None:
         """Block until the Metabase health endpoint reports ready."""
@@ -124,7 +131,7 @@ class MetabaseClient:
         instance is set up, so the decision is gated on ``has-user-setup`` to stay
         idempotent across runs.
         """
-        properties = self.request("GET", "/session/properties")
+        properties = self.request_dict("GET", "/session/properties")
         setup_token = properties.get("setup-token")
         has_user_setup = bool(properties.get("has-user-setup"))
         if setup_token and not has_user_setup:
@@ -147,7 +154,7 @@ class MetabaseClient:
                 "allow_tracking": False,
             },
         }
-        result = self.request("POST", "/setup", json=payload)
+        result = self.request_dict("POST", "/setup", json=payload)
         return str(result["id"])
 
     def _login(self) -> str:
@@ -155,7 +162,7 @@ class MetabaseClient:
             "username": self._settings.admin_email,
             "password": self._settings.admin_password,
         }
-        result = self.request("POST", "/session", json=payload)
+        result = self.request_dict("POST", "/session", json=payload)
         return str(result["id"])
 
 
@@ -179,12 +186,12 @@ def ensure_database(client: MetabaseClient, settings: MetabaseSettings) -> int:
             "host": settings.warehouse_host,
             "port": settings.warehouse_port,
             "dbname": settings.warehouse_db,
-            "user": settings.warehouse_user,
-            "password": settings.warehouse_password,
+            "user": settings.metabase_warehouse_user,
+            "password": settings.metabase_warehouse_password,
             "ssl": False,
         },
     }
-    created = client.request("POST", "/database", json=payload)
+    created = client.request_dict("POST", "/database", json=payload)
     return int(created["id"])
 
 
@@ -198,7 +205,7 @@ def ensure_collection(client: MetabaseClient) -> int:
         "name": metabase_config.COLLECTION_NAME,
         "description": "Dashboards y preguntas de la plataforma de datos de pozos.",
     }
-    created = client.request("POST", "/collection", json=payload)
+    created = client.request_dict("POST", "/collection", json=payload)
     return int(created["id"])
 
 
@@ -230,7 +237,7 @@ def ensure_card(
         card_id = existing[card.name]
         client.request("PUT", f"/card/{card_id}", json=payload)
         return card_id
-    created = client.request("POST", "/card", json=payload)
+    created = client.request_dict("POST", "/card", json=payload)
     return int(created["id"])
 
 
@@ -246,7 +253,7 @@ def ensure_dashboard(
             break
 
     if dashboard_id is None:
-        created = client.request(
+        created = client.request_dict(
             "POST",
             "/dashboard",
             json={

--- a/data_platform/bi/provision.py
+++ b/data_platform/bi/provision.py
@@ -1,0 +1,321 @@
+"""Idempotent provisioning of Metabase BI assets via its REST API.
+
+Reads the declarative definitions in :mod:`data_platform.bi.metabase_config` and
+applies them against a running Metabase instance: bootstraps the admin user (first
+run), registers the warehouse as a data source, and upserts the collection, cards and
+dashboard. Re-running the script converges to the same state without creating
+duplicates.
+
+Usage:
+    python -m data_platform.bi.provision
+
+Configuration is taken from environment variables (see ``.env.data.example``):
+    METABASE_URL, METABASE_ADMIN_EMAIL, METABASE_ADMIN_PASSWORD,
+    METABASE_ADMIN_FIRST_NAME, METABASE_ADMIN_LAST_NAME,
+    METABASE_WAREHOUSE_HOST, METABASE_WAREHOUSE_PORT,
+    WAREHOUSE_DB, WAREHOUSE_USER, WAREHOUSE_PASSWORD.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import sys
+import time
+from typing import Any
+
+import requests
+
+from data_platform.bi import metabase_config
+from data_platform.bi.metabase_config import Card
+
+REQUEST_TIMEOUT = 30
+HEALTH_RETRIES = 40
+HEALTH_DELAY_SECONDS = 3
+
+# Metabase dashboard grid is 24 columns wide; lay cards out two per row.
+GRID_WIDTH = 24
+CARD_WIDTH = 12
+CARD_HEIGHT = 8
+
+
+@dataclass(frozen=True)
+class MetabaseSettings:  # pylint: disable=too-many-instance-attributes
+    """Connection and bootstrap settings resolved from the environment."""
+
+    base_url: str
+    admin_email: str
+    admin_password: str
+    admin_first_name: str
+    admin_last_name: str
+    warehouse_host: str
+    warehouse_port: int
+    warehouse_db: str
+    warehouse_user: str
+    warehouse_password: str
+
+
+def settings_from_env() -> MetabaseSettings:
+    """Build :class:`MetabaseSettings` from environment variables with sane defaults."""
+    return MetabaseSettings(
+        base_url=os.getenv("METABASE_URL", "http://localhost:3002").rstrip("/"),
+        admin_email=os.getenv("METABASE_ADMIN_EMAIL", "admin@example.com"),
+        admin_password=os.getenv("METABASE_ADMIN_PASSWORD", "metabase123"),
+        admin_first_name=os.getenv("METABASE_ADMIN_FIRST_NAME", "Data"),
+        admin_last_name=os.getenv("METABASE_ADMIN_LAST_NAME", "Admin"),
+        warehouse_host=os.getenv("METABASE_WAREHOUSE_HOST", "warehouse"),
+        warehouse_port=int(os.getenv("METABASE_WAREHOUSE_PORT", "5432")),
+        warehouse_db=os.getenv("WAREHOUSE_DB", "warehouse"),
+        warehouse_user=os.getenv("WAREHOUSE_USER", "warehouse"),
+        warehouse_password=os.getenv("WAREHOUSE_PASSWORD", "warehouse"),
+    )
+
+
+class MetabaseClient:
+    """Thin authenticated wrapper around the Metabase REST API."""
+
+    def __init__(self, settings: MetabaseSettings) -> None:
+        self._settings = settings
+        self._session = requests.Session()
+        self._token: str | None = None
+
+    def _url(self, path: str) -> str:
+        return f"{self._settings.base_url}/api{path}"
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._token is not None:
+            headers["X-Metabase-Session"] = self._token
+        return headers
+
+    def request(self, method: str, path: str, **kwargs: Any) -> Any:
+        """Issue an API request and return the parsed JSON body (or ``None``)."""
+        response = self._session.request(
+            method,
+            self._url(path),
+            headers=self._headers(),
+            timeout=REQUEST_TIMEOUT,
+            **kwargs,
+        )
+        response.raise_for_status()
+        if not response.content:
+            return None
+        return response.json()
+
+    def wait_until_healthy(self) -> None:
+        """Block until the Metabase health endpoint reports ready."""
+        for attempt in range(1, HEALTH_RETRIES + 1):
+            try:
+                response = self._session.get(
+                    self._url("/health"), timeout=REQUEST_TIMEOUT
+                )
+                if response.ok:
+                    return
+            except requests.RequestException:
+                pass
+            print(f"Waiting for Metabase to be healthy ({attempt}/{HEALTH_RETRIES})...")
+            time.sleep(HEALTH_DELAY_SECONDS)
+        raise RuntimeError("Metabase did not become healthy in time")
+
+    def authenticate(self) -> None:
+        """Bootstrap the admin user on first run, otherwise log in.
+
+        Metabase keeps a non-null ``setup-token`` in the properties even after the
+        instance is set up, so the decision is gated on ``has-user-setup`` to stay
+        idempotent across runs.
+        """
+        properties = self.request("GET", "/session/properties")
+        setup_token = properties.get("setup-token")
+        has_user_setup = bool(properties.get("has-user-setup"))
+        if setup_token and not has_user_setup:
+            self._token = self._run_setup(setup_token)
+        else:
+            self._token = self._login()
+
+    def _run_setup(self, setup_token: str) -> str:
+        payload = {
+            "token": setup_token,
+            "user": {
+                "first_name": self._settings.admin_first_name,
+                "last_name": self._settings.admin_last_name,
+                "email": self._settings.admin_email,
+                "password": self._settings.admin_password,
+                "site_name": "Plataforma de Datos",
+            },
+            "prefs": {
+                "site_name": "Plataforma de Datos",
+                "allow_tracking": False,
+            },
+        }
+        result = self.request("POST", "/setup", json=payload)
+        return str(result["id"])
+
+    def _login(self) -> str:
+        payload = {
+            "username": self._settings.admin_email,
+            "password": self._settings.admin_password,
+        }
+        result = self.request("POST", "/session", json=payload)
+        return str(result["id"])
+
+
+def _as_list(response: Any) -> list[dict[str, Any]]:
+    """Normalize Metabase list responses (plain list or ``{"data": [...]}``)."""
+    if isinstance(response, dict):
+        return list(response.get("data", []))
+    return list(response)
+
+
+def ensure_database(client: MetabaseClient, settings: MetabaseSettings) -> int:
+    """Register the warehouse as a Postgres data source (idempotent by name)."""
+    for database in _as_list(client.request("GET", "/database")):
+        if database.get("name") == metabase_config.WAREHOUSE_DATABASE_NAME:
+            return int(database["id"])
+
+    payload = {
+        "name": metabase_config.WAREHOUSE_DATABASE_NAME,
+        "engine": "postgres",
+        "details": {
+            "host": settings.warehouse_host,
+            "port": settings.warehouse_port,
+            "dbname": settings.warehouse_db,
+            "user": settings.warehouse_user,
+            "password": settings.warehouse_password,
+            "ssl": False,
+        },
+    }
+    created = client.request("POST", "/database", json=payload)
+    return int(created["id"])
+
+
+def ensure_collection(client: MetabaseClient) -> int:
+    """Create the BI collection if it does not exist (idempotent by name)."""
+    for collection in _as_list(client.request("GET", "/collection")):
+        if collection.get("name") == metabase_config.COLLECTION_NAME:
+            return int(collection["id"])
+
+    payload = {
+        "name": metabase_config.COLLECTION_NAME,
+        "description": "Dashboards y preguntas de la plataforma de datos de pozos.",
+    }
+    created = client.request("POST", "/collection", json=payload)
+    return int(created["id"])
+
+
+def _card_payload(card: Card, database_id: int, collection_id: int) -> dict[str, Any]:
+    return {
+        "name": card.name,
+        "description": card.description,
+        "display": card.display,
+        "visualization_settings": card.visualization_settings(),
+        "collection_id": collection_id,
+        "dataset_query": {
+            "type": "native",
+            "database": database_id,
+            "native": {"query": card.sql, "template-tags": {}},
+        },
+    }
+
+
+def ensure_card(
+    client: MetabaseClient,
+    card: Card,
+    database_id: int,
+    collection_id: int,
+    existing: dict[str, int],
+) -> int:
+    """Create or update a single card (idempotent by name within the collection)."""
+    payload = _card_payload(card, database_id, collection_id)
+    if card.name in existing:
+        card_id = existing[card.name]
+        client.request("PUT", f"/card/{card_id}", json=payload)
+        return card_id
+    created = client.request("POST", "/card", json=payload)
+    return int(created["id"])
+
+
+def ensure_dashboard(
+    client: MetabaseClient, collection_id: int, card_ids: dict[str, int]
+) -> int:
+    """Create the dashboard and (re)attach its cards in a stable grid layout."""
+    dashboard = metabase_config.DASHBOARD
+    dashboard_id: int | None = None
+    for existing in _as_list(client.request("GET", "/dashboard")):
+        if existing.get("name") == dashboard.name:
+            dashboard_id = int(existing["id"])
+            break
+
+    if dashboard_id is None:
+        created = client.request(
+            "POST",
+            "/dashboard",
+            json={
+                "name": dashboard.name,
+                "description": dashboard.description,
+                "collection_id": collection_id,
+            },
+        )
+        dashboard_id = int(created["id"])
+
+    dashcards = []
+    for index, card_name in enumerate(dashboard.card_names):
+        dashcards.append(
+            {
+                "id": -(index + 1),
+                "card_id": card_ids[card_name],
+                "row": (index // 2) * CARD_HEIGHT,
+                "col": (index % 2) * CARD_WIDTH,
+                "size_x": CARD_WIDTH,
+                "size_y": CARD_HEIGHT,
+            }
+        )
+
+    client.request("PUT", f"/dashboard/{dashboard_id}", json={"dashcards": dashcards})
+    return dashboard_id
+
+
+def provision() -> int:
+    """Run the full idempotent provisioning flow. Returns the dashboard id."""
+    settings = settings_from_env()
+    client = MetabaseClient(settings)
+
+    client.wait_until_healthy()
+    client.authenticate()
+
+    database_id = ensure_database(client, settings)
+    collection_id = ensure_collection(client)
+
+    existing_cards = {
+        card["name"]: int(card["id"])
+        for card in _as_list(client.request("GET", "/card"))
+        if card.get("collection_id") == collection_id
+    }
+
+    card_ids: dict[str, int] = {}
+    for card in metabase_config.CARDS:
+        card_ids[card.name] = ensure_card(
+            client, card, database_id, collection_id, existing_cards
+        )
+
+    dashboard_id = ensure_dashboard(client, collection_id, card_ids)
+
+    print(
+        f"Provisioned database id={database_id}, collection id={collection_id}, "
+        f"{len(card_ids)} cards, dashboard id={dashboard_id} "
+        f"at {settings.base_url}/dashboard/{dashboard_id}"
+    )
+    return dashboard_id
+
+
+def main() -> int:
+    """Entry point for ``python -m data_platform.bi.provision``."""
+    try:
+        provision()
+    except (requests.RequestException, RuntimeError, KeyError) as exc:
+        print(f"Provisioning failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker-compose.data.yml
+++ b/docker-compose.data.yml
@@ -89,6 +89,7 @@ services:
       MB_DB_DBNAME: ${METABASE_DB_NAME:-metabase}
       MB_DB_USER: ${METABASE_DB_USER:-metabase}
       MB_DB_PASS: ${METABASE_DB_PASSWORD:-metabase}
+      MB_ENCRYPTION_SECRET_KEY: ${MB_ENCRYPTION_SECRET_KEY}
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:3000/api/health"]
       interval: 15s

--- a/docker-compose.data.yml
+++ b/docker-compose.data.yml
@@ -55,6 +55,48 @@ services:
       - dagster_home:/opt/dagster/dagster_home
       - ./data_platform:/opt/dagster/app/data_platform
 
+  # Dedicated Postgres for Metabase's own application metadata. Kept separate from the
+  # warehouse so BI internal state never mixes with analytical data.
+  metabase-db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: ${METABASE_DB_USER:-metabase}
+      POSTGRES_PASSWORD: ${METABASE_DB_PASSWORD:-metabase}
+      POSTGRES_DB: ${METABASE_DB_NAME:-metabase}
+    volumes:
+      - metabase_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${METABASE_DB_USER:-metabase}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # BI for non-technical users. Connects to the warehouse gold schema as a data source;
+  # that connection plus dashboards are applied reproducibly via data_platform.bi.provision.
+  metabase:
+    image: metabase/metabase:v0.62.1.7
+    ports:
+      - "${METABASE_PORT:-3002}:3000"
+    depends_on:
+      warehouse:
+        condition: service_healthy
+      metabase-db:
+        condition: service_healthy
+    environment:
+      MB_DB_TYPE: postgres
+      MB_DB_HOST: metabase-db
+      MB_DB_PORT: "5432"
+      MB_DB_DBNAME: ${METABASE_DB_NAME:-metabase}
+      MB_DB_USER: ${METABASE_DB_USER:-metabase}
+      MB_DB_PASS: ${METABASE_DB_PASSWORD:-metabase}
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:3000/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+
 volumes:
   warehouse_data:
   dagster_home:
+  metabase_db_data:

--- a/docs/ADRs/18-bi-tool.md
+++ b/docs/ADRs/18-bi-tool.md
@@ -1,0 +1,63 @@
+# ADR-18: Herramienta de BI para usuarios no tecnicos
+
+```
+status: Aceptado
+date: 2026-06-14
+decision-makers: Equipo de Desarrollo
+```
+
+## Contexto y declaracion del problema
+
+La capa gold ya expone un modelo estrella consultable y una marca de calidad
+(`gold.quality_marks`), pero falta una plataforma de BI que permita a usuarios no
+tecnicos explorar esos datos y armar dashboards sin escribir SQL. La herramienta debe
+conectar al warehouse Postgres, correr en el stack local de Docker Compose y dejar la
+configuracion de los dashboards versionada y reproducible.
+
+## Impulsores de la decision
+
+* Acceso self-service para perfiles no tecnicos (requisito funcional de la fase).
+* Conexion nativa al warehouse Postgres y al esquema gold.
+* Despliegue en un contenedor dentro del Compose de datos existente.
+* Dashboards reproducibles a partir de configuracion versionada.
+* Mantener los datos en el entorno local/controlado, sin exfiltrarlos.
+
+## Opciones consideradas
+
+* **Metabase** - BI self-service orientado a no tecnicos, con question builder sin SQL.
+* **Apache Superset** - BI potente y flexible, mas orientado a perfiles tecnicos.
+* **Looker Studio** - BI gestionado de Google, sin infraestructura propia.
+
+## Resultado de la decision
+
+Opcion elegida: **Metabase**.
+
+Superset es mas potente para visualizaciones avanzadas, pero su curva de uso
+(construccion de charts, SQL Lab) apunta a perfiles tecnicos y choca con el requisito de
+"usuarios no tecnicos". Looker Studio es gestionado y comodo, pero implica sacar los
+datos del entorno local hacia un servicio de Google y atar la solucion a ese proveedor.
+Metabase permite explorar y armar dashboards con el question builder sin escribir SQL,
+conecta nativo a Postgres y levanta en un unico contenedor junto al resto del stack.
+
+La configuracion no se deja como estado mutable dentro de Metabase: se define de forma
+declarativa en `data_platform/bi/metabase_config.py` (conexion, preguntas y dashboard) y
+se aplica de forma idempotente con `data_platform/bi/provision.py` contra la REST API.
+Asi la configuracion queda versionada y reproducible sin depender de la serializacion de
+la edicion Enterprise. El metadata interno de Metabase corre en un Postgres propio
+(`metabase-db`), separado del warehouse.
+
+## Consecuencias
+
+* Bueno, porque los no tecnicos arman consultas y dashboards sin SQL.
+* Bueno, porque conecta nativo a Postgres y corre en el Compose de datos.
+* Bueno, porque los dashboards quedan versionados y se reaplican de forma idempotente.
+* Bueno, porque el estado interno de Metabase no se mezcla con los datos analiticos.
+* Malo, porque es menos flexible que Superset para visualizaciones avanzadas.
+* Malo, porque la provision por API depende de la estabilidad de los endpoints REST.
+
+## Confirmacion
+
+Confirmado en `docker-compose.data.yml` (servicios `metabase` y `metabase-db`),
+`data_platform/bi/` (config declarativa y script de provision) y en los tests
+`tests/test_metabase_config.py` (estructura de las cards) y
+`tests/test_metabase_cards_sql.py` (cada query valida contra el gold real).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ data = [
     "dagster-webserver>=1.8,<2.0",
     "dagster-dbt>=0.20,<1.0",
     "psycopg2-binary>=2.9,<3.0",
+    "requests>=2.31,<3.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_metabase_cards_sql.py
+++ b/tests/test_metabase_cards_sql.py
@@ -1,0 +1,56 @@
+"""Smoke test that every Metabase card SQL is valid against the gold warehouse.
+
+This is the BI equivalent of a connection check: each card is the exact native query
+Metabase will issue, so running ``EXPLAIN`` against the live gold schema proves the
+queries reference real tables and columns. It uses the shared ``warehouse_connection``
+fixture and is skipped when no warehouse (or no built gold layer) is available.
+"""
+
+# pylint: disable=wrong-import-position
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+psycopg2 = pytest.importorskip("psycopg2")
+
+from data_platform.bi import metabase_config  # noqa: E402
+
+REQUIRED_GOLD_TABLES = ("fct_produccion", "quality_marks")
+
+
+def _gold_is_built(connection: Any) -> bool:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            select count(*)
+            from information_schema.tables
+            where table_schema = 'gold'
+              and table_name = any(%s)
+            """,
+            (list(REQUIRED_GOLD_TABLES),),
+        )
+        (count,) = cursor.fetchone()
+    return bool(count == len(REQUIRED_GOLD_TABLES))
+
+
+@pytest.fixture
+def gold_connection(warehouse_connection: Any) -> Any:
+    """Yield a warehouse connection, skipping if the gold layer is not built."""
+    if not _gold_is_built(warehouse_connection):
+        pytest.skip("gold layer is not built in the warehouse")
+    return warehouse_connection
+
+
+@pytest.mark.parametrize(
+    "card", metabase_config.CARDS, ids=[card.name for card in metabase_config.CARDS]
+)
+def test_card_sql_explains_against_gold(card: Any, gold_connection: Any) -> None:
+    """Each card's native SQL must EXPLAIN cleanly against the real gold schema."""
+    with gold_connection.cursor() as cursor:
+        try:
+            cursor.execute(f"EXPLAIN {card.sql}")
+        finally:
+            gold_connection.rollback()

--- a/tests/test_metabase_config.py
+++ b/tests/test_metabase_config.py
@@ -1,0 +1,71 @@
+"""Unit tests for the declarative Metabase BI configuration.
+
+These run without a warehouse or a running Metabase: they validate the structural
+integrity of the cards and dashboard defined in
+:mod:`data_platform.bi.metabase_config`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_platform.bi import metabase_config
+from data_platform.bi.metabase_config import (
+    DISPLAY_TABLE,
+    VALID_DISPLAYS,
+)
+
+
+def test_card_names_are_unique() -> None:
+    """Each card has a distinct name (provisioning matches by name)."""
+    names = [card.name for card in metabase_config.CARDS]
+    assert len(names) == len(set(names))
+
+
+def test_every_card_queries_the_gold_schema() -> None:
+    """Cards have non-empty SQL that reads from the gold layer."""
+    for card in metabase_config.CARDS:
+        assert card.sql.strip(), f"{card.name} has empty SQL"
+        assert "gold." in card.sql, f"{card.name} does not read from the gold schema"
+
+
+def test_every_card_has_a_valid_display() -> None:
+    """Cards use a supported Metabase visualization type."""
+    for card in metabase_config.CARDS:
+        assert card.display in VALID_DISPLAYS
+
+
+def test_graph_cards_define_axes_and_tables_do_not() -> None:
+    """Charts map dimensions and metrics; tables carry no axis settings."""
+    for card in metabase_config.CARDS:
+        settings = card.visualization_settings()
+        if card.display == DISPLAY_TABLE:
+            assert not settings
+            assert not card.dimensions
+            assert not card.metrics
+        else:
+            assert card.dimensions, f"{card.name} is a chart without dimensions"
+            assert card.metrics, f"{card.name} is a chart without metrics"
+            assert settings["graph.dimensions"] == list(card.dimensions)
+            assert settings["graph.metrics"] == list(card.metrics)
+
+
+def test_dashboard_references_only_existing_cards() -> None:
+    """Every card referenced by the dashboard is a defined card."""
+    available = metabase_config.card_names()
+    assert metabase_config.DASHBOARD.card_names
+    for name in metabase_config.DASHBOARD.card_names:
+        assert name in available
+
+
+def test_quality_mark_card_is_present() -> None:
+    """The data quality mark is exposed as a table over gold.quality_marks."""
+    quality = metabase_config.get_card("Marca de calidad de los datos")
+    assert "gold.quality_marks" in quality.sql
+    assert quality.display == DISPLAY_TABLE
+
+
+def test_get_card_raises_for_unknown_name() -> None:
+    """Looking up an unknown card name raises KeyError."""
+    with pytest.raises(KeyError):
+        metabase_config.get_card("does-not-exist")

--- a/uv.lock
+++ b/uv.lock
@@ -1517,6 +1517,7 @@ data = [
     { name = "dbt-core" },
     { name = "dbt-postgres" },
     { name = "psycopg2-binary" },
+    { name = "requests" },
 ]
 dev = [
     { name = "black" },
@@ -1546,6 +1547,7 @@ data = [
     { name = "dbt-core", specifier = ">=1.8,<2.0" },
     { name = "dbt-postgres", specifier = ">=1.8,<2.0" },
     { name = "psycopg2-binary", specifier = ">=2.9,<3.0" },
+    { name = "requests", specifier = ">=2.31,<3.0" },
 ]
 dev = [
     { name = "black", specifier = ">=24.10.0,<25.0.0" },


### PR DESCRIPTION
## Fase 2 - PR 8: BI con Metabase

Implementa la capa de BI con Metabase para que usuarios no tecnicos exploren la capa
`gold`, segun `docs/fase-2-plan.md`.

### Que incluye
- **Compose**: servicios `metabase` (`v0.62.1.7`, puerto `3002`) y `metabase-db`
  (Postgres dedicado al metadata de Metabase, separado del warehouse) en
  `docker-compose.data.yml` + variables en `.env.data.example`.
- **Provisioning reproducible**: paquete `data_platform/bi/` con
  `metabase_config.py` (config declarativa versionada: 5 cards + dashboard) y
  `provision.py` (script idempotente contra la REST API). Las cards: gas por cuenca,
  petroleo por operadora, top pozos, evolucion mensual y la marca de calidad de los datos.
- **Docs**: `docs/ADRs/18-bi-tool.md` (Metabase vs Superset vs Looker Studio) y seccion de
  acceso en `README.md`.
- **Tests/CI**: `tests/test_metabase_config.py` (unit) y `tests/test_metabase_cards_sql.py`
  (`EXPLAIN` de cada card contra gold real); este ultimo se corre en el job `dbt-test`.

### Dependencia (branching apilado del plan)
Anidada localmente sobre `feature/data-quality` (necesita `gold.quality_marks` para el
dashboard de calidad). **El PR apunta a `develop`** segun la regla del plan. Debe mergearse
**despues** de los PRs upstream (gold -> data-quality), bottom-up; hasta entonces el diff
mostrara tambien esos cambios y se limpia solo al re-basearse.

### Verificacion realizada localmente
- `dbt run --full-refresh --select silver gold` -> gold construido (PASS=10).
- `pytest tests/test_metabase_cards_sql.py` -> las 5 cards hacen `EXPLAIN` OK contra gold.
- `docker compose up metabase metabase-db` + `python -m data_platform.bi.provision` ->
  database + collection + 5 cards + dashboard creados; re-ejecucion **idempotente**
  (sin duplicados).
- `pre-commit run` (black/flake8/pylint/mypy) limpio; suite base `pytest` en verde.
