### PR TITLE
feat(bi): KPIs, card por tipo de recurso y filtro de fecha en el dashboard

### DIFF
--- a/data_platform/bi/metabase_config.py
+++ b/data_platform/bi/metabase_config.py
@@ -25,7 +25,16 @@ COLLECTION_NAME = "Plataforma de Datos - Pozos"
 DISPLAY_LINE = "line"
 DISPLAY_BAR = "bar"
 DISPLAY_TABLE = "table"
-VALID_DISPLAYS = frozenset({DISPLAY_LINE, DISPLAY_BAR, DISPLAY_TABLE})
+DISPLAY_SCALAR = "scalar"
+VALID_DISPLAYS = frozenset({DISPLAY_LINE, DISPLAY_BAR, DISPLAY_TABLE, DISPLAY_SCALAR})
+
+# Single dashboard-level date range filter. Cards that opt in (``date_filtered``)
+# embed this Metabase field-filter placeholder in their SQL; the provisioner wires
+# it to a ``date/all-options`` parameter on the dashboard. Field filters generate a
+# fully-qualified ``"gold"."fct_produccion"."periodo"`` reference, so opted-in cards
+# must keep ``gold.fct_produccion`` un-aliased in their outer query.
+PERIOD_FILTER_TAG = "periodo_filter"
+PERIOD_FILTER_PLACEHOLDER = "{{" + PERIOD_FILTER_TAG + "}}"
 
 
 @dataclass(frozen=True)
@@ -71,14 +80,19 @@ class Card:  # pylint: disable=too-many-instance-attributes
     conditional_formats: tuple[ColumnFormatRule, ...] = field(default_factory=tuple)
     # Whether this card spans the full dashboard width instead of half.
     full_width: bool = False
+    # Whether this card participates in the dashboard-level date range filter.
+    date_filtered: bool = False
 
     def visualization_settings(self) -> dict[str, Any]:
         """Build Metabase ``visualization_settings`` for this card's display.
 
-        Tables optionally carry conditional-formatting rules; line and bar charts
-        map result columns to the dimension (x axis / breakout) and metric (y axis)
-        roles, and may pin some metrics to the secondary (right) axis.
+        Scalars carry no axis settings. Tables optionally carry conditional-formatting
+        rules; line and bar charts map result columns to the dimension (x axis /
+        breakout) and metric (y axis) roles, and may pin some metrics to the secondary
+        (right) axis.
         """
+        if self.display == DISPLAY_SCALAR:
+            return {}
         if self.display == DISPLAY_TABLE:
             if not self.conditional_formats:
                 return {}
@@ -109,6 +123,61 @@ class Dashboard:
 
 CARDS: tuple[Card, ...] = (
     Card(
+        name="Producción acumulada de gas",
+        description=(
+            "Gas total producido en el período seleccionado (responde al filtro de "
+            "fecha del dashboard)."
+        ),
+        sql=(
+            "select sum(fct_produccion.prod_gas) as gas_acumulado\n"
+            "from gold.fct_produccion\n"
+            "where " + PERIOD_FILTER_PLACEHOLDER
+        ),
+        display=DISPLAY_SCALAR,
+        date_filtered=True,
+    ),
+    Card(
+        name="Producción acumulada de petróleo",
+        description=(
+            "Petróleo total producido en el período seleccionado (responde al filtro "
+            "de fecha del dashboard)."
+        ),
+        sql=(
+            "select sum(fct_produccion.prod_petroleo) as petroleo_acumulado\n"
+            "from gold.fct_produccion\n"
+            "where " + PERIOD_FILTER_PLACEHOLDER
+        ),
+        display=DISPLAY_SCALAR,
+        date_filtered=True,
+    ),
+    Card(
+        name="Pozos activos en el último mes",
+        description=(
+            "Cantidad de pozos con producción (gas o petróleo) en el último mes "
+            "cargado. Indicador de actividad; no se ve afectado por el filtro de fecha."
+        ),
+        sql=(
+            "select count(distinct fct_produccion.id_pozo) as pozos_activos\n"
+            "from gold.fct_produccion\n"
+            "where fct_produccion.periodo = "
+            "(select max(periodo) from gold.fct_produccion)\n"
+            "    and (fct_produccion.prod_gas + fct_produccion.prod_petroleo) > 0"
+        ),
+        display=DISPLAY_SCALAR,
+    ),
+    Card(
+        name="Último período cargado",
+        description=(
+            "Mes más reciente con datos en la capa gold. Señal de frescura; siempre "
+            "muestra el último período real, sin importar el filtro de fecha."
+        ),
+        sql=(
+            "select max(fct_produccion.periodo) as ultimo_periodo\n"
+            "from gold.fct_produccion"
+        ),
+        display=DISPLAY_SCALAR,
+    ),
+    Card(
         name="Producción de gas por cuenca",
         description=(
             "Gas producido por cuenca a lo largo del tiempo, para comparar la "
@@ -116,17 +185,20 @@ CARDS: tuple[Card, ...] = (
         ),
         sql=(
             "select\n"
-            "    f.periodo as periodo,\n"
+            "    fct_produccion.periodo as periodo,\n"
             "    c.cuenca as cuenca,\n"
-            "    sum(f.prod_gas) as prod_gas\n"
-            "from gold.fct_produccion as f\n"
-            "join gold.dim_cuenca as c on f.cuenca_key = c.cuenca_key\n"
-            "group by f.periodo, c.cuenca\n"
-            "order by f.periodo, c.cuenca"
+            "    sum(fct_produccion.prod_gas) as prod_gas\n"
+            "from gold.fct_produccion\n"
+            "join gold.dim_cuenca as c "
+            "on fct_produccion.cuenca_key = c.cuenca_key\n"
+            "where " + PERIOD_FILTER_PLACEHOLDER + "\n"
+            "group by fct_produccion.periodo, c.cuenca\n"
+            "order by fct_produccion.periodo, c.cuenca"
         ),
         display=DISPLAY_LINE,
         dimensions=("periodo", "cuenca"),
         metrics=("prod_gas",),
+        date_filtered=True,
     ),
     Card(
         name="Producción de petróleo por operadora",
@@ -152,31 +224,61 @@ CARDS: tuple[Card, ...] = (
             "    from ranking\n"
             ")\n"
             "select\n"
-            "    f.periodo as periodo,\n"
+            "    fct_produccion.periodo as periodo,\n"
             "    t.grupo as operadora,\n"
-            "    sum(f.prod_petroleo) as prod_petroleo\n"
-            "from gold.fct_produccion as f\n"
-            "join gold.dim_empresa as e on f.empresa_key = e.empresa_key\n"
+            "    sum(fct_produccion.prod_petroleo) as prod_petroleo\n"
+            "from gold.fct_produccion\n"
+            "join gold.dim_empresa as e "
+            "on fct_produccion.empresa_key = e.empresa_key\n"
             "join etiqueta as t on t.operadora = e.empresa\n"
-            "group by f.periodo, t.grupo\n"
-            "order by f.periodo, t.grupo"
+            "where " + PERIOD_FILTER_PLACEHOLDER + "\n"
+            "group by fct_produccion.periodo, t.grupo\n"
+            "order by fct_produccion.periodo, t.grupo"
         ),
         display=DISPLAY_LINE,
         dimensions=("periodo", "operadora"),
         metrics=("prod_petroleo",),
+        date_filtered=True,
+    ),
+    Card(
+        name="Producción por tipo de recurso",
+        description=(
+            "Producción total (gas + petróleo) separada por tipo de recurso "
+            "(convencional vs. no convencional) a lo largo del tiempo. Da contexto al "
+            "foco no convencional del dashboard."
+        ),
+        sql=(
+            "select\n"
+            "    fct_produccion.periodo as periodo,\n"
+            "    tr.tipo_recurso as tipo_recurso,\n"
+            "    sum(fct_produccion.prod_gas + fct_produccion.prod_petroleo) "
+            "as produccion_total\n"
+            "from gold.fct_produccion\n"
+            "join gold.dim_tipo_recurso as tr "
+            "on fct_produccion.tipo_recurso_key = tr.tipo_recurso_key\n"
+            "where " + PERIOD_FILTER_PLACEHOLDER + "\n"
+            "group by fct_produccion.periodo, tr.tipo_recurso\n"
+            "order by fct_produccion.periodo, tr.tipo_recurso"
+        ),
+        display=DISPLAY_LINE,
+        dimensions=("periodo", "tipo_recurso"),
+        metrics=("produccion_total",),
+        date_filtered=True,
     ),
     Card(
         name="Top pozos por producción acumulada",
         description=(
-            "Los 20 pozos con mayor producción acumulada (gas + petróleo) en todo el "
-            "período disponible."
+            "Los 20 pozos con mayor producción acumulada (gas + petróleo) en el "
+            "período seleccionado."
         ),
         sql=(
             "select\n"
             "    p.sigla as pozo,\n"
-            "    sum(f.prod_gas + f.prod_petroleo) as produccion_total\n"
-            "from gold.fct_produccion as f\n"
-            "join gold.dim_pozo as p on f.pozo_key = p.pozo_key\n"
+            "    sum(fct_produccion.prod_gas + fct_produccion.prod_petroleo) "
+            "as produccion_total\n"
+            "from gold.fct_produccion\n"
+            "join gold.dim_pozo as p on fct_produccion.pozo_key = p.pozo_key\n"
+            "where " + PERIOD_FILTER_PLACEHOLDER + "\n"
             "group by p.sigla\n"
             "order by produccion_total desc\n"
             "limit 20"
@@ -184,6 +286,7 @@ CARDS: tuple[Card, ...] = (
         display=DISPLAY_BAR,
         dimensions=("pozo",),
         metrics=("produccion_total",),
+        date_filtered=True,
     ),
     Card(
         name="Evolución mensual de producción total",
@@ -192,13 +295,14 @@ CARDS: tuple[Card, ...] = (
         ),
         sql=(
             "select\n"
-            "    f.periodo as periodo,\n"
-            "    sum(f.prod_gas) as prod_gas,\n"
-            "    sum(f.prod_petroleo) as prod_petroleo,\n"
-            "    sum(f.prod_agua) as prod_agua\n"
-            "from gold.fct_produccion as f\n"
-            "group by f.periodo\n"
-            "order by f.periodo"
+            "    fct_produccion.periodo as periodo,\n"
+            "    sum(fct_produccion.prod_gas) as prod_gas,\n"
+            "    sum(fct_produccion.prod_petroleo) as prod_petroleo,\n"
+            "    sum(fct_produccion.prod_agua) as prod_agua\n"
+            "from gold.fct_produccion\n"
+            "where " + PERIOD_FILTER_PLACEHOLDER + "\n"
+            "group by fct_produccion.periodo\n"
+            "order by fct_produccion.periodo"
         ),
         display=DISPLAY_LINE,
         dimensions=("periodo",),
@@ -206,6 +310,7 @@ CARDS: tuple[Card, ...] = (
         # Gas dwarfs petróleo/agua early on; move the smaller series to the right
         # axis so they stay readable instead of flattening against zero.
         right_axis_metrics=("prod_petroleo", "prod_agua"),
+        date_filtered=True,
     ),
     Card(
         name="Marca de calidad de los datos",
@@ -248,8 +353,9 @@ CARDS: tuple[Card, ...] = (
 DASHBOARD = Dashboard(
     name="Producción de pozos no convencionales",
     description=(
-        "Vista para usuarios no técnicos: producción por cuenca y operadora, top "
-        "pozos, evolución mensual y la marca de calidad de los datos."
+        "Vista para usuarios no técnicos: KPIs de producción, producción por cuenca, "
+        "operadora y tipo de recurso, top pozos, evolución mensual y la marca de "
+        "calidad de los datos. El filtro de fecha acota el período de los gráficos."
     ),
     card_names=tuple(card.name for card in CARDS),
 )
@@ -266,3 +372,13 @@ def get_card(name: str) -> Card:
         if card.name == name:
             return card
     raise KeyError(name)
+
+
+def sql_for_validation(card: Card) -> str:
+    """Return the card SQL with the date filter placeholder rendered as a no-op.
+
+    Metabase replaces an unset field filter with a tautology; mirroring that here lets
+    the SQL be EXPLAIN-checked against the warehouse without a live Metabase to expand
+    the ``{{periodo_filter}}`` template tag.
+    """
+    return card.sql.replace(PERIOD_FILTER_PLACEHOLDER, "true")

--- a/data_platform/bi/provision.py
+++ b/data_platform/bi/provision.py
@@ -33,10 +33,25 @@ REQUEST_TIMEOUT = 30
 HEALTH_RETRIES = 40
 HEALTH_DELAY_SECONDS = 3
 
-# Metabase dashboard grid is 24 columns wide; lay cards out two per row.
+# Resolving the periodo field id needs the gold schema scanned; on a fresh instance
+# the first sync is asynchronous, so retry while nudging Metabase to re-sync.
+SYNC_RETRIES = 20
+SYNC_DELAY_SECONDS = 3
+
+# Metabase dashboard grid is 24 columns wide. Charts take half a row, the quality
+# table the full width and KPI scalars a quarter so four sit on one row.
 GRID_WIDTH = 24
 CARD_WIDTH = 12
 CARD_HEIGHT = 8
+SCALAR_WIDTH = 6
+SCALAR_HEIGHT = 4
+
+# Single dashboard-level date range filter wired to each opted-in card's field filter.
+PERIOD_PARAM_ID = "periodo01"
+PERIOD_PARAM_NAME = "Período"
+PERIOD_PARAM_SLUG = "periodo"
+PERIOD_FILTER_WIDGET = "date/all-options"
+PERIOD_FILTER_TAG_ID = "periodo-filter-tag"
 
 
 @dataclass(frozen=True)
@@ -257,7 +272,51 @@ def ensure_collection(client: MetabaseClient) -> int:
     return int(created["id"])
 
 
-def _card_payload(card: Card, database_id: int, collection_id: int) -> dict[str, Any]:
+def resolve_periodo_field_id(client: MetabaseClient, database_id: int) -> int:
+    """Return the Metabase field id of ``gold.fct_produccion.periodo``.
+
+    The date filter is a field filter, so it needs the warehouse field id, which only
+    exists once Metabase has scanned the schema. On a fresh instance that scan is
+    asynchronous; nudge a re-sync and retry until the field appears.
+    """
+    for attempt in range(1, SYNC_RETRIES + 1):
+        metadata = client.request_dict("GET", f"/database/{database_id}/metadata")
+        for table in metadata.get("tables", []):
+            if (
+                table.get("schema") == metabase_config.WAREHOUSE_SCHEMA
+                and table.get("name") == "fct_produccion"
+            ):
+                for field in table.get("fields", []):
+                    if field.get("name") == "periodo":
+                        return int(field["id"])
+        client.request("POST", f"/database/{database_id}/sync_schema")
+        print(
+            "Waiting for gold.fct_produccion.periodo to be synced "
+            f"({attempt}/{SYNC_RETRIES})..."
+        )
+        time.sleep(SYNC_DELAY_SECONDS)
+    raise RuntimeError("gold.fct_produccion.periodo field was not synced in time")
+
+
+def _template_tags(card: Card, periodo_field_id: int) -> dict[str, Any]:
+    """Field-filter template tag for opted-in cards; empty otherwise."""
+    if not card.date_filtered:
+        return {}
+    return {
+        metabase_config.PERIOD_FILTER_TAG: {
+            "id": PERIOD_FILTER_TAG_ID,
+            "name": metabase_config.PERIOD_FILTER_TAG,
+            "display-name": PERIOD_PARAM_NAME,
+            "type": "dimension",
+            "dimension": ["field", periodo_field_id, None],
+            "widget-type": PERIOD_FILTER_WIDGET,
+        }
+    }
+
+
+def _card_payload(
+    card: Card, database_id: int, collection_id: int, periodo_field_id: int
+) -> dict[str, Any]:
     return {
         "name": card.name,
         "description": card.description,
@@ -267,7 +326,10 @@ def _card_payload(card: Card, database_id: int, collection_id: int) -> dict[str,
         "dataset_query": {
             "type": "native",
             "database": database_id,
-            "native": {"query": card.sql, "template-tags": {}},
+            "native": {
+                "query": card.sql,
+                "template-tags": _template_tags(card, periodo_field_id),
+            },
         },
     }
 
@@ -278,9 +340,10 @@ def ensure_card(
     database_id: int,
     collection_id: int,
     existing: dict[str, int],
+    periodo_field_id: int,
 ) -> int:
     """Create or update a single card (idempotent by name within the collection)."""
-    payload = _card_payload(card, database_id, collection_id)
+    payload = _card_payload(card, database_id, collection_id, periodo_field_id)
     if card.name in existing:
         card_id = existing[card.name]
         client.request("PUT", f"/card/{card_id}", json=payload)
@@ -312,16 +375,31 @@ def ensure_dashboard(
         )
         dashboard_id = int(created["id"])
 
+    client.request(
+        "PUT",
+        f"/dashboard/{dashboard_id}",
+        json={
+            "dashcards": _build_dashcards(card_ids),
+            "parameters": _dashboard_parameters(),
+        },
+    )
+    return dashboard_id
+
+
+def _build_dashcards(card_ids: dict[str, int]) -> list[dict[str, Any]]:
+    """Lay the dashboard cards out on the 24-column grid, wrapping by row height."""
     dashcards = []
     row = 0
     col = 0
-    for index, card_name in enumerate(dashboard.card_names):
-        full_width = metabase_config.get_card(card_name).full_width
-        width = GRID_WIDTH if full_width else CARD_WIDTH
+    row_height = 0
+    for index, card_name in enumerate(metabase_config.DASHBOARD.card_names):
+        card = metabase_config.get_card(card_name)
+        width, height = _card_size(card)
         # Wrap to the next row when the card does not fit in the remaining width.
         if col + width > GRID_WIDTH:
-            row += CARD_HEIGHT
+            row += row_height
             col = 0
+            row_height = 0
         dashcards.append(
             {
                 "id": -(index + 1),
@@ -329,16 +407,55 @@ def ensure_dashboard(
                 "row": row,
                 "col": col,
                 "size_x": width,
-                "size_y": CARD_HEIGHT,
+                "size_y": height,
+                "parameter_mappings": _parameter_mappings(card, card_ids[card_name]),
             }
         )
         col += width
+        row_height = max(row_height, height)
         if col >= GRID_WIDTH:
-            row += CARD_HEIGHT
+            row += row_height
             col = 0
+            row_height = 0
+    return dashcards
 
-    client.request("PUT", f"/dashboard/{dashboard_id}", json={"dashcards": dashcards})
-    return dashboard_id
+
+def _card_size(card: Card) -> tuple[int, int]:
+    """Return the (width, height) of a card on the 24-column dashboard grid."""
+    if card.full_width:
+        return GRID_WIDTH, CARD_HEIGHT
+    if card.display == metabase_config.DISPLAY_SCALAR:
+        return SCALAR_WIDTH, SCALAR_HEIGHT
+    return CARD_WIDTH, CARD_HEIGHT
+
+
+def _dashboard_parameters() -> list[dict[str, Any]]:
+    """The single date range filter exposed on the dashboard."""
+    return [
+        {
+            "id": PERIOD_PARAM_ID,
+            "name": PERIOD_PARAM_NAME,
+            "slug": PERIOD_PARAM_SLUG,
+            "type": PERIOD_FILTER_WIDGET,
+            "sectionId": "date",
+        }
+    ]
+
+
+def _parameter_mappings(card: Card, card_id: int) -> list[dict[str, Any]]:
+    """Link the dashboard date filter to a card's field-filter template tag."""
+    if not card.date_filtered:
+        return []
+    return [
+        {
+            "parameter_id": PERIOD_PARAM_ID,
+            "card_id": card_id,
+            "target": [
+                "dimension",
+                ["template-tag", metabase_config.PERIOD_FILTER_TAG],
+            ],
+        }
+    ]
 
 
 def provision() -> int:
@@ -353,6 +470,7 @@ def provision() -> int:
 
     database_id = ensure_database(client, settings)
     collection_id = ensure_collection(client)
+    periodo_field_id = resolve_periodo_field_id(client, database_id)
 
     existing_cards = {
         card["name"]: int(card["id"])
@@ -363,7 +481,7 @@ def provision() -> int:
     card_ids: dict[str, int] = {}
     for card in metabase_config.CARDS:
         card_ids[card.name] = ensure_card(
-            client, card, database_id, collection_id, existing_cards
+            client, card, database_id, collection_id, existing_cards, periodo_field_id
         )
 
     dashboard_id = ensure_dashboard(client, collection_id, card_ids)

--- a/tests/test_metabase_cards_sql.py
+++ b/tests/test_metabase_cards_sql.py
@@ -49,8 +49,9 @@ def gold_connection(warehouse_connection: Any) -> Any:
 )
 def test_card_sql_explains_against_gold(card: Any, gold_connection: Any) -> None:
     """Each card's native SQL must EXPLAIN cleanly against the real gold schema."""
+    sql = metabase_config.sql_for_validation(card)
     with gold_connection.cursor() as cursor:
         try:
-            cursor.execute(f"EXPLAIN {card.sql}")
+            cursor.execute(f"EXPLAIN {sql}")
         finally:
             gold_connection.rollback()

--- a/tests/test_metabase_config.py
+++ b/tests/test_metabase_config.py
@@ -11,7 +11,10 @@ import pytest
 
 from data_platform.bi import metabase_config
 from data_platform.bi.metabase_config import (
+    DISPLAY_LINE,
+    DISPLAY_SCALAR,
     DISPLAY_TABLE,
+    PERIOD_FILTER_PLACEHOLDER,
     VALID_DISPLAYS,
 )
 
@@ -35,11 +38,11 @@ def test_every_card_has_a_valid_display() -> None:
         assert card.display in VALID_DISPLAYS
 
 
-def test_graph_cards_define_axes_and_tables_do_not() -> None:
-    """Charts map dimensions and metrics; tables carry no axis settings."""
+def test_graph_cards_define_axes_and_others_do_not() -> None:
+    """Charts map dimensions and metrics; tables and scalars carry no axis settings."""
     for card in metabase_config.CARDS:
         settings = card.visualization_settings()
-        if card.display == DISPLAY_TABLE:
+        if card.display in (DISPLAY_TABLE, DISPLAY_SCALAR):
             assert "graph.dimensions" not in settings
             assert "graph.metrics" not in settings
             assert not card.dimensions
@@ -49,6 +52,73 @@ def test_graph_cards_define_axes_and_tables_do_not() -> None:
             assert card.metrics, f"{card.name} is a chart without metrics"
             assert settings["graph.dimensions"] == list(card.dimensions)
             assert settings["graph.metrics"] == list(card.metrics)
+
+
+def test_scalar_cards_are_single_value_kpis() -> None:
+    """The KPI cards render as scalars over the gold layer with empty settings."""
+    expected = {
+        "Producción acumulada de gas",
+        "Producción acumulada de petróleo",
+        "Pozos activos en el último mes",
+        "Último período cargado",
+    }
+    scalars = {
+        card.name for card in metabase_config.CARDS if card.display == DISPLAY_SCALAR
+    }
+    assert scalars == expected
+    for name in expected:
+        card = metabase_config.get_card(name)
+        assert not card.visualization_settings()
+        assert "gold." in card.sql
+
+
+def test_tipo_recurso_card_splits_by_resource_type() -> None:
+    """A line card breaks production down by tipo de recurso."""
+    card = metabase_config.get_card("Producción por tipo de recurso")
+    assert card.display == DISPLAY_LINE
+    assert "gold.dim_tipo_recurso" in card.sql
+    assert card.dimensions == ("periodo", "tipo_recurso")
+
+
+def test_date_filter_placeholder_matches_opt_in_flag() -> None:
+    """A card embeds the date filter placeholder iff it opts into the date filter."""
+    for card in metabase_config.CARDS:
+        has_placeholder = PERIOD_FILTER_PLACEHOLDER in card.sql
+        assert has_placeholder == card.date_filtered, card.name
+
+
+def test_unfiltered_cards_are_freshness_and_quality() -> None:
+    """KPIs meant as 'latest' signals and the quality table ignore the date filter."""
+    unfiltered = {card.name for card in metabase_config.CARDS if not card.date_filtered}
+    assert unfiltered == {
+        "Pozos activos en el último mes",
+        "Último período cargado",
+        "Marca de calidad de los datos",
+    }
+
+
+def test_date_filtered_cards_keep_fct_unaliased_in_outer_query() -> None:
+    """Field filters reference the physical table, so the outer fct is not aliased.
+
+    A CTE may still alias fct in its own scope (the filter never expands there); what
+    matters is that the query the filter lands in selects from an un-aliased
+    ``gold.fct_produccion`` and never aliases it on the same line as the ``where``.
+    """
+    for card in metabase_config.CARDS:
+        if not card.date_filtered:
+            continue
+        # The field filter expands to "gold"."fct_produccion"."periodo"; an outer
+        # alias would shadow that and break the query when a value is applied.
+        assert "from gold.fct_produccion\n" in card.sql, card.name
+        assert metabase_config.PERIOD_FILTER_PLACEHOLDER in card.sql, card.name
+
+
+def test_validation_sql_renders_filter_placeholder_as_noop() -> None:
+    """The placeholder is rendered to a tautology for offline SQL validation."""
+    card = metabase_config.get_card("Producción de gas por cuenca")
+    rendered = metabase_config.sql_for_validation(card)
+    assert PERIOD_FILTER_PLACEHOLDER not in rendered
+    assert "where true" in rendered
 
 
 def test_secondary_axis_metrics_are_emitted_as_series_settings() -> None:


### PR DESCRIPTION
## Qué

Agrega tres cosas al dashboard de Metabase "Producción de pozos no convencionales", usando datos que ya estaban materializados en la capa gold pero que ninguna card consumía:

1. **Fila de KPIs (scalars):** producción acumulada de gas, producción acumulada de petróleo, pozos activos en el último mes y último período cargado.
2. **Card "Producción por tipo de recurso"** (línea sobre `dim_tipo_recurso`): da el corte convencional vs. no convencional que el título del dashboard implica y que hasta ahora no estaba.
3. **Filtro de rango de fecha** a nivel dashboard ("Período"), cableado a los 5 gráficos de producción y a los 2 KPIs acumulados. Los KPIs de frescura ("último mes" / "último período") y la tabla de calidad lo ignoran a propósito.

Todo sigue el patrón declarativo existente: las cards son dataclasses en `metabase_config.py` y el provisioning (parámetro, mappings, resolución del field id, layout) en `provision.py`. Re-correr `provision` converge al mismo estado.

## Detalle técnico

Los field filters de Metabase expanden a una referencia totalmente calificada `"gold"."fct_produccion"."periodo"`, que choca con un alias de tabla. Por eso las cards que participan del filtro mantienen `fct_produccion` sin alias en su query externa (verificado empíricamente contra la instancia: con alias el query rompe al aplicar un valor). Cambio mecánico y que preserva resultados.

El provisioner resuelve el id del campo `periodo` en tiempo de ejecución (forzando un sync del esquema si hace falta) y ahora ubica las cards con ancho/alto variables para acomodar la fila de KPIs.

## Pruebas

- `tests/test_metabase_config.py` y `tests/test_metabase_cards_sql.py`: estructura de las cards nuevas, displays scalar, consistencia del opt-in al filtro y EXPLAIN de cada SQL contra el gold real (con el placeholder renderizado como no-op).
- `tests/test_metabase_e2e.py`: 5 pass contra la instancia provisionada (parámetro presente, 7 cards cableadas, filtro recorta correctamente a un rango).
- `pre-commit` (black, flake8, pylint, mypy): verde.