### PR TITLE
Fase 3 PR1: base MLOps y ADRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+.pre-commit-cache/
+.uv-cache/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ La documentación técnica completa está en [`docs/`](docs/index.md):
 - [Load Testing](docs/load-testing.md) — tráfico sintético con Locust
 - [Gobierno de datos](docs/governance.md) — quickstart local de DataHub
 - [Ops](docs/ops.md) — deploy, secretos y monitoreo operativo
+- [Plan Fase 3](docs/planes/fase-3.md) — PRs, ADRs y handoff para ML Engineering
 - [Runbook de Data Engineer](docs/runbooks/data-engineer.md) — backfill histórico y verificación de reprocesos
 - [Runbook de BI User](docs/runbooks/bi-user.md) — validar frescura y calidad antes de publicar
 
@@ -138,6 +139,44 @@ por query (`MB_*_QUERY_ROW_LIMIT`) por encima del default de 2000 para que ningu
 trunque silenciosamente al crecer los datos. Las credenciales por defecto
 (`METABASE_ADMIN_*`, `MB_ENCRYPTION_SECRET_KEY`, `metabase_ro`) son solo para uso local:
 rotalas y usa un secreto aleatorio real en cualquier despliegue compartido.
+
+## Plataforma ML Engineering (Fase 3 - en desarrollo)
+
+La Fase 3 integra el servicio de predicciones con un flujo reproducible de ML Engineering.
+El objetivo es que las features usadas por entrenamiento e inferencia queden persistidas,
+que cada entrenamiento registre metricas y artefactos, y que la API pueda servir el modelo
+vigente con trazabilidad hacia el run que lo genero.
+
+Arquitectura objetivo:
+
+```text
+gold / warehouse
+      |
+      v
+feature store persistido
+      |
+      +--> training dataset por as_of_date --> training + validation
+                                              |
+                                              v
+                                      MLflow tracking + registry
+                                              |
+                                              v
+API REST --> modelo vigente + lookup de features --> prediccion
+```
+
+El desarrollo se divide en PRs chicos y documentados en
+[`docs/planes/fase-3.md`](docs/planes/fase-3.md). Las decisiones clave estan cubiertas
+por ADRs comparativos:
+
+- [ADR-20](docs/ADRs/20-experiment-tracking.md) — tracking de experimentos
+- [ADR-21](docs/ADRs/21-feature-store.md) — feature store persistido
+- [ADR-22](docs/ADRs/22-model-registry.md) — registro y promocion de modelos
+- [ADR-23](docs/ADRs/23-training-orchestration.md) — orquestacion de training/retraining
+- [ADR-24](docs/ADRs/24-ml-pipeline-cicd.md) — CI/CD de pipelines ML
+
+La entrega de esta fase no requiere servicio live en produccion. La demostracion final se
+enfoca en evidencia local: runs con metricas en MLflow, llamadas a la API con distintas
+condiciones, modelo vigente registrado y trigger manual/recurrente de retraining.
 ## Plataforma de datos (Dagster)
 
 El pipeline corre como un grafo de assets de Dagster: los assets de bronze

--- a/docs/ADRs/20-experiment-tracking.md
+++ b/docs/ADRs/20-experiment-tracking.md
@@ -1,0 +1,71 @@
+# ADR-20: Tracking de experimentos de machine learning
+
+```
+status: Propuesto
+date: 2026-06-25
+decision-makers: Equipo de Desarrollo
+```
+
+## Contexto y declaracion del problema
+
+La Fase 3 requiere que los ML Engineers puedan acceder a una plataforma de tracking de
+experimentos. El entrenamiento debe ser reproducible y comparable entre runs, dejando
+evidencia de parametros, metricas, artefactos, ventana de datos y version de features.
+La entrega no exige un servicio live en produccion, pero si una demostracion local clara
+de multiples entrenamientos y sus metricas.
+
+## Impulsores de la decision
+
+* Registrar metricas comparables entre runs, como MAE, RMSE y cantidad de filas.
+* Registrar parametros y tags de reproducibilidad: `as_of_date`, ventana temporal,
+  feature view y commit.
+* Guardar artefactos de modelo para que puedan registrarse/promoverse despues.
+* Correr localmente sin depender de servicios SaaS externos.
+* Integrarse con un model registry sin construir una plataforma propia.
+
+## Opciones consideradas
+
+* **MLflow Tracking** - plataforma open source para registrar experimentos, metricas,
+  parametros, tags y artefactos. Puede correr localmente en Docker Compose y se integra
+  con MLflow Model Registry.
+* **Weights & Biases** - tracking y visualizacion muy completos, con excelente UI para
+  colaboracion, pero normalmente depende de un servicio externo y de una cuenta SaaS.
+* **Neptune** - alternativa gestionada fuerte para equipos ML, tambien con dependencia
+  externa y mayor superficie operativa para esta entrega.
+* **CSV/JSON propio** - simple de implementar, pero no cumple bien la necesidad de
+  comparar runs, navegar metricas ni conectar tracking con registry.
+
+## Resultado de la decision
+
+Opcion propuesta: **MLflow Tracking**.
+
+MLflow cubre el requisito de plataforma de tracking sin sumar una dependencia SaaS. Su
+modelo de runs permite registrar parametros, metricas, tags y artefactos de manera
+reproducible, y su UI local es suficiente para la demostracion del video. Ademas, deja el
+camino abierto para usar MLflow Model Registry en ADR-22 sin inventar metadatos propios.
+
+Weights & Biases y Neptune ofrecen mejor experiencia gestionada y colaborativa, pero
+agregan cuentas externas, configuracion de tokens y dependencia de red que no aporta
+valor suficiente para una entrega local. CSV/JSON propio seria barato al inicio, pero
+terminaria recreando mal una parte de MLflow y haria mas debil la evidencia del video.
+
+## Consecuencias
+
+**Pros**
+
+* Los ML Engineers pueden comparar runs desde una UI local.
+* Los artefactos quedan relacionados con metricas y parametros.
+* Se reduce el trabajo necesario para conectar training con model registry.
+* La demo puede mostrar multiples runs reales sin produccion live.
+
+**Cons**
+
+* Agrega un servicio local adicional y volumen de artefactos.
+* Requiere acordar convenciones de experimentos, tags y nombres de modelo.
+* En un entorno productivo real habria que endurecer almacenamiento, permisos y backups.
+
+## Confirmacion esperada
+
+Confirmar en PR 3 con servicio MLflow local, helpers en `ml/training/tracking.py`, al
+menos un smoke test de registro de runs y un entrenamiento real registrando metricas.
+

--- a/docs/ADRs/21-feature-store.md
+++ b/docs/ADRs/21-feature-store.md
@@ -1,0 +1,66 @@
+# ADR-21: Feature store persistido para entrenamiento e inferencia
+
+```
+status: Propuesto
+date: 2026-06-25
+decision-makers: Equipo de Desarrollo
+```
+
+## Contexto y declaracion del problema
+
+La Fase 3 exige que el procesamiento y generacion de features quede persistido en un
+feature store usado durante la inferencia. El sistema ya cuenta con warehouse PostgreSQL,
+modelos dbt en silver/gold y orquestacion Dagster. La decision debe evitar que training e
+inferencia calculen features por caminos distintos, porque eso produciria training-serving
+skew.
+
+## Impulsores de la decision
+
+* Persistir features, no solo construirlas en memoria durante el entrenamiento.
+* Consultar las mismas features desde training y desde la API.
+* Reprocesar features para un `as_of_date` dado.
+* Evitar leakage temporal usando solo informacion disponible hasta la fecha de corte.
+* Reutilizar Postgres, dbt y Dagster ya presentes en la plataforma de datos.
+
+## Opciones consideradas
+
+* **Postgres como feature store** - esquema o modelos dedicados de features dentro del
+  warehouse, materializados por dbt/Dagster y consultados por Python.
+* **Feast** - feature store dedicado con abstracciones offline/online, historizacion y
+  serving, pero con mayor complejidad operativa.
+* **Parquet versionado** - archivos particionados por fecha, simples para entrenamiento
+  batch, pero incomodos para lookup online desde la API.
+
+## Resultado de la decision
+
+Opcion propuesta: **Postgres como feature store persistido**.
+
+Postgres ya es el motor elegido para la plataforma de datos en ADR-12 y ya se conecta con
+dbt, Dagster y la API. Para el alcance de la materia, un esquema `ml_features` con tablas
+o vistas materializadas por fecha cubre persistencia, reproducibilidad y lookup desde
+inferencia sin introducir una herramienta nueva. Feast es conceptualmente mas completo,
+pero su valor aparece cuando existen multiples fuentes, store online separado, equipos
+grandes o necesidades de baja latencia mas estrictas. Parquet es atractivo para batch,
+pero obliga a resolver de nuevo el serving desde la API.
+
+## Consecuencias
+
+**Pros**
+
+* Reusa el warehouse y las credenciales ya documentadas.
+* Permite materializar y validar features con dbt/Dagster.
+* Simplifica la demo: se pueden inspeccionar las features con SQL.
+* Evita una plataforma adicional para la entrega local.
+
+**Cons**
+
+* No provee abstracciones nativas de feature registry como Feast.
+* Para escala o baja latencia real podria requerir un store online separado.
+* El equipo debe definir convenciones propias para nombres, granularidad y freshness.
+
+## Confirmacion esperada
+
+Confirmar en PR 2 con modelos/tablas persistidas bajo `ml_features`, codigo de lectura en
+`ml/features/store.py`, tests de idempotencia, lookup por fecha y ausencia de leakage
+temporal.
+

--- a/docs/ADRs/22-model-registry.md
+++ b/docs/ADRs/22-model-registry.md
@@ -1,0 +1,63 @@
+# ADR-22: Registro y promocion de modelos
+
+```
+status: Propuesto
+date: 2026-06-25
+decision-makers: Equipo de Desarrollo
+```
+
+## Contexto y declaracion del problema
+
+La API de predicciones necesita resolver que modelo esta vigente y exponer metadata de la
+version servida. El equipo tambien necesita trazar cada modelo hasta el run de
+entrenamiento, las metricas de validacion, los parametros y el artefacto generado. Sin un
+registry, la promocion de modelos quedaria como un proceso manual y dificil de auditar.
+
+## Impulsores de la decision
+
+* Versionar modelos entrenados.
+* Relacionar modelo, run, metricas y artefacto.
+* Distinguir modelos promovidos, candidatos y rechazados.
+* Permitir que la API consulte el modelo vigente sin hardcodear paths.
+* Evitar construir un registry propio con semantica incompleta.
+
+## Opciones consideradas
+
+* **MLflow Model Registry** - registro integrado con MLflow Tracking, versiones de modelo,
+  metadata y resolucion de modelos por nombre/version.
+* **Artefactos versionados + JSON** - guardar modelos en carpetas y metadata en archivos,
+  con baja complejidad inicial pero poca seguridad operativa.
+* **Tabla propia en Postgres** - metadata controlada por el equipo, pero implica disenar
+  reglas de versionado, promocion y resolucion de artefactos.
+
+## Resultado de la decision
+
+Opcion propuesta: **MLflow Model Registry**.
+
+Como ADR-20 propone MLflow Tracking, usar MLflow Model Registry evita duplicar metadata y
+mantiene la trazabilidad run-modelo en una misma plataforma. La API podra resolver el
+modelo vigente por nombre y version/stage, mientras que el pipeline de entrenamiento
+podra registrar y promover candidatos segun metricas. Artefactos + JSON es demasiado
+fragil para auditar promocion, y una tabla propia en Postgres recrearia funcionalidades
+que MLflow ya provee.
+
+## Consecuencias
+
+**Pros**
+
+* Trazabilidad directa entre run, metricas y modelo servido.
+* Menos codigo propio para versionado y promocion.
+* La demo puede mostrar el modelo registrado/promovido junto a los runs.
+* Facilita el endpoint `GET /models/current`.
+
+**Cons**
+
+* Acopla training e inferencia a convenciones de MLflow.
+* La API necesita manejar claramente el caso "no hay modelo promovido".
+* En produccion real habria que definir permisos y almacenamiento robusto para artefactos.
+
+## Confirmacion esperada
+
+Confirmar en PR 6 con helpers en `ml/registry/`, politica de promocion, tests de modelos
+promovidos/rechazados y API resolviendo el modelo vigente.
+

--- a/docs/ADRs/23-training-orchestration.md
+++ b/docs/ADRs/23-training-orchestration.md
@@ -1,0 +1,61 @@
+# ADR-23: Orquestacion de entrenamiento y retraining
+
+```
+status: Propuesto
+date: 2026-06-25
+decision-makers: Equipo de Desarrollo
+```
+
+## Contexto y declaracion del problema
+
+La Fase 3 exige repetir el proceso de entrenamiento para un dia dado y ejecutar
+entrenamiento/despliegue de modelos de manera recurrente y automatica. La plataforma ya
+usa Dagster para orquestar la capa de datos, con assets, particiones, schedules y
+validacion en CI.
+
+## Impulsores de la decision
+
+* Ejecutar retraining parametrizado por `as_of_date`.
+* Disparar retraining manual para la demo.
+* Programar retraining recurrente.
+* Observar estado, logs y fallas desde una UI local.
+* Reutilizar la orquestacion existente sin sumar otro stack.
+
+## Opciones consideradas
+
+* **Dagster** - jobs/assets/schedules definidos como codigo, UI local y reutilizacion del
+  stack de Fase 2.
+* **GitHub Actions scheduled workflow** - simple para cron, pero pobre para observar
+  lineage, estado de assets y triggers parametrizados desde UI.
+* **Apache Airflow** - maduro para DAGs, pero agregaria un segundo orquestador al repo.
+
+## Resultado de la decision
+
+Opcion propuesta: **Dagster para retraining ML**.
+
+Dagster ya esta incorporado, validado en CI y documentado para reprocesos por fecha. Usar
+un `train_model_job` parametrizable por `as_of_date` permite demostrar retraining manual
+desde la UI y schedule recurrente sin sumar Airflow ni depender de GitHub Actions para la
+operacion diaria. GitHub Actions queda mejor ubicado como CI/CD de validacion de
+pipelines, no como orquestador principal de ML.
+
+## Consecuencias
+
+**Pros**
+
+* Unifica pipelines de datos y ML en el mismo orquestador.
+* Permite mostrar trigger manual y schedule en la demo.
+* Reutiliza patrones de assets, jobs y validations ya presentes.
+* Evita operar Airflow solo para esta fase.
+
+**Cons**
+
+* Aumenta la responsabilidad del stack Dagster local.
+* Hay que cuidar que el job de training no quede acoplado a estado local no reproducible.
+* GitHub Actions seguira siendo necesario para validar cambios antes de mergear.
+
+## Confirmacion esperada
+
+Confirmar en PR 7 con `train_model_job`, schedule recurrente, config por `as_of_date`,
+validacion de definitions y runbook de trigger manual.
+

--- a/docs/ADRs/24-ml-pipeline-cicd.md
+++ b/docs/ADRs/24-ml-pipeline-cicd.md
@@ -1,0 +1,63 @@
+# ADR-24: CI/CD para pipelines de ML
+
+```
+status: Propuesto
+date: 2026-06-25
+decision-makers: Equipo de Desarrollo
+```
+
+## Contexto y declaracion del problema
+
+La consigna exige que los pipelines de procesamiento se desplieguen mediante CI/CD. En
+esta entrega no hay servicio live en produccion, por lo que el objetivo practico es que
+cada PR valide automaticamente los componentes de ML Engineering: feature store,
+training, registry, orquestacion y contrato API.
+
+## Impulsores de la decision
+
+* Mantener checks automaticos por PR.
+* No depender de secretos reales ni servicios externos.
+* Reutilizar la infraestructura de GitHub Actions ya existente.
+* Validar dbt, Dagster, training smoke y tests de API/registry.
+* Dejar comandos locales equivalentes para reproducir fallas.
+
+## Opciones consideradas
+
+* **GitHub Actions** - CI ya configurado en el repo, con soporte para service containers y
+  jobs independientes.
+* **Deploy manual/local** - rapido para una demo, pero no cumple automatizacion ni deja
+  evidencia en PRs.
+* **Dagster Cloud u orquestador gestionado** - potente para operacion, pero excede el
+  alcance local y agrega costo/cuenta externa.
+* **Jenkins/GitLab CI** - validos, pero no estan integrados con este repositorio.
+
+## Resultado de la decision
+
+Opcion propuesta: **GitHub Actions como CI/CD de pipelines ML**.
+
+El repositorio ya valida API, dbt, Dagster, DataHub y Metabase con GitHub Actions. Extender
+esa misma plataforma para ML mantiene una unica superficie de CI, evita nuevos servicios
+y permite usar Postgres como service container para smoke tests. El despliegue live queda
+fuera de alcance por consigna, pero CI debe demostrar que los pipelines se pueden construir
+y ejecutar de forma reproducible.
+
+## Consecuencias
+
+**Pros**
+
+* Cada PR deja evidencia automatica de integracion.
+* No se introducen proveedores nuevos.
+* Los fallos de training/registry/API se detectan antes del merge.
+* Los comandos locales pueden copiarse del workflow.
+
+**Cons**
+
+* Los smoke tests deben ser chicos para no volver lenta la CI.
+* La CI no reemplaza una operacion productiva real de modelos.
+* Puede requerir fixtures reducidas para evitar depender de datos externos.
+
+## Confirmacion esperada
+
+Confirmar en PR 8 con jobs CI de ML, smoke training, validacion de Dagster definitions,
+tests de registry/API y documentacion de comandos locales equivalentes.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,5 +13,6 @@
 | [Load Testing](load-testing.md) | Tráfico sintético con Locust, presets y ejecución |
 | [Gobierno de datos](governance.md) | Quickstart local de DataHub para catalogo y gobierno |
 | [Ops](ops.md) | Deploy, secretos y monitoreo operativo en alto nivel |
+| [Plan Fase 3](planes/fase-3.md) | Plan vivo de PRs, ADRs y handoff para ML Engineering |
 | [Runbook de Data Engineer](runbooks/data-engineer.md) | Reproceso histórico de particiones, verificación de idempotencia y revisión de resultados |
 | [Runbook de BI User](runbooks/bi-user.md) | Validar frescura y calidad (quality_marks + DataHub) antes de publicar un reporte |

--- a/docs/planes/fase-3.md
+++ b/docs/planes/fase-3.md
@@ -1,0 +1,960 @@
+# Plan de PRs - Fase 3: ML Engineering para la API predictiva
+
+Fecha de entrega: 2026-07-11
+
+## Como usar este documento vivo
+
+Este archivo es el punto de entrada para cualquier persona o agente que continue el
+desarrollo de Fase 3. Antes de empezar un PR, leer:
+
+1. `AGENTS.md`
+2. `README.md`
+3. `docs/planes/fase-3.md`
+4. Los ADRs asociados al PR en curso
+5. Los tests existentes que toquen la misma superficie
+
+Cada PR debe actualizar esta seccion antes de cerrarse:
+
+| Campo | Valor |
+|-------|-------|
+| Ultima actualizacion | 2026-06-25 |
+| Branch base esperada | `develop` sincronizada con `origin/develop` |
+| Estado global | PR 1 listo para review |
+| Siguiente PR recomendado | PR 2 - `feature/ml-feature-store`, PR 3 - `feature/mlflow-tracking` o PR 4 - `feature/prediction-api-contract` |
+| Riesgo abierto principal | `pre-commit run --all-files` no pudo completar porque el entorno no pudo descargar hooks desde GitHub |
+
+### Regla de handoff entre agentes
+
+Al terminar un PR, agregar una nota breve en el bloque del PR con:
+
+* estado: `pendiente`, `en progreso`, `listo para review`, `mergeado` o `bloqueado`
+* branch real usada
+* commits principales
+* comandos de verificacion corridos
+* archivos tocados mas importantes
+* decisiones nuevas o desviaciones contra este plan
+* siguiente PR desbloqueado
+
+No borrar contexto historico util. Si una decision cambia, marcar la anterior como
+reemplazada y explicar por que.
+
+## Contexto y alcance
+
+La Fase 3 agrega una capa de ML Engineering sobre la plataforma existente. El sistema ya
+tiene API REST, monitoreo, warehouse Postgres, dbt, Dagster, DataHub y Metabase. La nueva
+fase debe demostrar que la API de predicciones queda integrada con un proceso reproducible
+de features, entrenamiento, tracking, registro de modelos, validacion, retraining y CI/CD.
+
+Requisitos cubiertos por esta fase:
+
+* Usuarios de API consumen predicciones por API REST.
+* ML Engineers acceden a tracking de experimentos.
+* Features usadas en inferencia quedan persistidas en un feature store.
+* El entrenamiento es reproducible para un dia dado.
+* El entrenamiento y despliegue de modelos corren de forma recurrente y automatica.
+* Los pipelines de procesamiento se validan/despliegan por CI/CD.
+* La arquitectura completa queda documentada en `README.md`.
+* El video muestra integracion real: runs, metricas, llamadas API y trigger de retrain.
+
+## Arquitectura objetivo
+
+Flujo esperado:
+
+```text
+Data Warehouse / gold
+        |
+        v
+Feature Store persistido
+        |
+        +------> Training dataset por as_of_date
+        |              |
+        |              v
+        |        Training + Validation
+        |              |
+        |              v
+        |        MLflow Tracking + Model Registry
+        |              |
+        |              v
+        +------> Modelo promovido
+                       |
+                       v
+API REST ------> carga modelo vigente + consulta features ------> prediccion
+
+Dagster orquesta materializacion de features, training, validacion y retrain.
+GitHub Actions valida pipelines, tests, dbt/Dagster y smoke tests de ML.
+```
+
+## Stack propuesto
+
+| Capa | Herramienta elegida | Alternativas a comparar en ADR | Motivo resumido |
+|------|---------------------|--------------------------------|-----------------|
+| Feature store | Postgres en esquema dedicado | Feast, parquet versionado | Reusa warehouse y dbt/Dagster; suficiente para el alcance local |
+| Experiment tracking | MLflow Tracking | Weights & Biases, Neptune, CSV/JSON propio | Corre local, registra params/metrics/artifacts y es estandar academico/profesional |
+| Model registry | MLflow Model Registry | Artefactos versionados en storage, tabla propia en Postgres | Integra tracking + modelos + stages sin inventar registry propio |
+| Orquestacion ML | Dagster jobs/assets | GitHub Actions cron, Airflow | Ya esta en el repo y permite retrain por fecha con observabilidad |
+| CI/CD pipelines | GitHub Actions | Deploy manual, Dagster Cloud, Jenkins | Ya esta configurado; permite validar sin servicio live en produccion |
+
+## Estrategia de PRs
+
+Se planifican **9 PRs**, divisible por 3 personas. La regla es que cada PR sea revisable
+por separado y deje evidencia verificable. Evitar PRs gigantes que mezclen ADRs,
+infraestructura, training, API y video.
+
+### Branching
+
+* Crear cada branch desde la dependencia inmediata real.
+* Si el PR depende de otro aun no mergeado, crear branch apilada sobre esa branch.
+* Si el PR padre ya fue mergeado, rebasear o recrear desde `develop` actualizado.
+* Mantener el orden de merge indicado en la tabla.
+* Antes de empezar: `git fetch` y verificar que `develop` este al dia con `origin/develop`.
+
+### Distribucion sugerida para 3 personas
+
+| Persona | PRs sugeridos | Foco |
+|---------|---------------|------|
+| A | PR 2, PR 5, PR 8 | feature store, dataset/training, CI/CD |
+| B | PR 3, PR 6, PR 9 | MLflow, registry/promocion, documentacion/demo |
+| C | PR 1, PR 4, PR 7 | foundation, API, retraining/orquestacion |
+
+La asignacion es flexible, pero el total queda balanceado: 3 PRs por persona.
+
+## Matriz de PRs
+
+| PR | Branch | Owner sugerido | Depende de | Estado | Entrega principal |
+|----|--------|----------------|------------|--------|-------------------|
+| 1 | `feature/mlops-foundation` | C | `develop` | listo para review | estructura ML + ADRs iniciales + README arquitectura base |
+| 2 | `feature/ml-feature-store` | A | PR 1 | pendiente | feature store persistido y materializacion |
+| 3 | `feature/mlflow-tracking` | B | PR 1 | pendiente | MLflow local + tracking helpers |
+| 4 | `feature/prediction-api-contract` | C | PR 1 | pendiente | contrato API de prediccion y tests base |
+| 5 | `feature/training-pipeline` | A | PR 2 + PR 3 | pendiente | entrenamiento reproducible por `as_of_date` |
+| 6 | `feature/model-registry-promotion` | B | PR 3 + PR 5 | pendiente | registro, validacion y promocion de modelos |
+| 7 | `feature/retraining-orchestration` | C | PR 2 + PR 5 + PR 6 | pendiente | retrain manual/recurrente con Dagster |
+| 8 | `feature/ml-pipeline-cicd` | A | PR 5 + PR 6 + PR 7 | pendiente | CI/CD de pipelines ML |
+| 9 | `feature/phase3-docs-demo` | B | PR 1-8 | pendiente | README final, runbook y guion/evidencia de video |
+
+---
+
+## PR 1: `feature/mlops-foundation`
+
+**Branch:** `feature/mlops-foundation` desde `develop` actualizado
+**Owner sugerido:** C
+**Descripcion:** Cimientos documentales y estructura minima para que los otros PRs puedan
+trabajar en paralelo sin inventar carpetas ni nombres.
+
+### Que implementar
+
+1. Crear estructura base:
+   * `ml/__init__.py`
+   * `ml/features/__init__.py`
+   * `ml/training/__init__.py`
+   * `ml/registry/__init__.py`
+   * `ml/inference/__init__.py`
+   * `ml/config.py` si hace falta centralizar paths/env vars.
+
+2. Actualizar `README.md` con una seccion inicial de arquitectura Fase 3:
+   * API REST
+   * feature store
+   * training
+   * validation
+   * experiment tracking
+   * model registry
+   * retraining
+   * CI/CD
+   * nota explicita: no hay servicio live de produccion para la entrega.
+
+3. Crear ADRs base como borradores completos:
+   * `docs/ADRs/20-experiment-tracking.md`
+   * `docs/ADRs/21-feature-store.md`
+   * `docs/ADRs/22-model-registry.md`
+   * `docs/ADRs/23-training-orchestration.md`
+   * `docs/ADRs/24-ml-pipeline-cicd.md`
+
+4. Agregar referencia desde `docs/index.md` si corresponde.
+
+### ADRs de este PR
+
+Los ADRs pueden quedar con decision preliminar, pero deben incluir comparacion real de
+alternativas desde el primer PR. No crear ADRs vacios ni documentos que solo describan
+"lo que hicimos".
+
+Ver la seccion "Detalle de ADRs de Fase 3" para el contenido esperado.
+
+### Verificacion
+
+```bash
+uv run pytest
+uv run pre-commit run --all-files
+```
+
+Si `pre-commit` queda bloqueado por el entorno, correr al menos tests y linters sobre los
+archivos tocados, y anotar el bloqueo en este plan.
+
+### Handoff
+
+* Estado: listo para review
+* Branch real: `feature/mlops-foundation`
+* Comandos corridos:
+  * `$env:UV_CACHE_DIR='.uv-cache'; $env:PYTEST_ADDOPTS='-p no:cacheprovider'; uv run pytest` -> 133 passed, 20 skipped
+  * `$env:UV_CACHE_DIR='.uv-cache'; uv run black --config .pre-commit/.black.toml --check ml tests/test_ml_config.py`
+  * `$env:UV_CACHE_DIR='.uv-cache'; uv run flake8 --config .pre-commit/.flake8 ml tests/test_ml_config.py`
+  * `$env:UV_CACHE_DIR='.uv-cache'; uv run pylint --rcfile .pre-commit/.pylintrc --persistent=n ml tests/test_ml_config.py`
+  * `$env:UV_CACHE_DIR='.uv-cache'; uv run mypy --config-file .pre-commit/mypy.ini ml tests/test_ml_config.py`
+  * `$env:UV_CACHE_DIR='.uv-cache'; $env:PYTEST_ADDOPTS='-p no:cacheprovider'; uv run pytest tests/test_ml_config.py`
+  * `$env:UV_CACHE_DIR='.uv-cache'; $env:PRE_COMMIT_HOME='.pre-commit-cache'; $env:GIT_CONFIG_COUNT='1'; $env:GIT_CONFIG_KEY_0='safe.directory'; $env:GIT_CONFIG_VALUE_0='C:/Users/tomas/OneDrive/Documents/GitHub/ingenieria-software'; uv run pre-commit run --all-files` -> bloqueado al descargar `https://github.com/psf/black/`
+* Archivos clave:
+  * `.gitignore`
+  * `ml/config.py`
+  * `tests/test_ml_config.py`
+  * `docs/ADRs/20-experiment-tracking.md`
+  * `docs/ADRs/21-feature-store.md`
+  * `docs/ADRs/22-model-registry.md`
+  * `docs/ADRs/23-training-orchestration.md`
+  * `docs/ADRs/24-ml-pipeline-cicd.md`
+  * `docs/planes/fase-3.md`
+  * `README.md`
+  * `docs/index.md`
+* Siguiente PR desbloqueado: PR 2, PR 3 y PR 4
+
+---
+
+## PR 2: `feature/ml-feature-store`
+
+**Branch:** `feature/ml-feature-store` desde PR 1 o `develop` si PR 1 ya fue mergeado
+**Owner sugerido:** A
+**Descripcion:** Persistir features de inferencia/entrenamiento en Postgres, reusando el
+warehouse y los modelos gold existentes.
+
+### Que implementar
+
+1. Definir un esquema o convencion para features:
+   * recomendado: esquema `ml_features` o modelos dbt bajo `data_platform/transform/models/ml_features/`.
+   * grano sugerido: `pozo_id` o identificador de pozo + `as_of_date`.
+   * no usar datos futuros respecto de `as_of_date`.
+
+2. Crear features iniciales para prediccion:
+   * produccion historica reciente por pozo
+   * medias/ventanas moviles simples
+   * tendencia simple
+   * dias/meses con produccion disponible
+   * atributos estables del pozo desde gold/silver si aportan valor.
+
+3. Crear codigo de acceso:
+   * `ml/features/store.py`
+   * funciones tipadas para leer features por pozo y fecha.
+   * errores claros cuando faltan features.
+
+4. Integrar materializacion en Dagster o dbt:
+   * asset/job para materializar features por fecha.
+   * idempotencia al re-materializar la misma fecha.
+
+5. Tests:
+   * lectura de features por fecha.
+   * idempotencia.
+   * ausencia de leakage temporal.
+   * error controlado si no hay features.
+
+### ADR asociado
+
+Completar `docs/ADRs/21-feature-store.md`.
+
+Decision recomendada: **Postgres como feature store persistido**.
+
+Alternativas obligatorias:
+
+* Postgres/dbt/Dagster sobre el warehouse existente.
+* Feast.
+* Parquet versionado o archivos locales.
+
+### Verificacion
+
+```bash
+uv run --group data python -m data_platform.ci.seed_bronze
+uv run --group data dbt build --select silver gold --project-dir data_platform/transform --profiles-dir data_platform/transform
+uv run --group data pytest tests/test_feature_store.py
+```
+
+Si se agregan modelos dbt de features, sumar:
+
+```bash
+uv run --group data dbt build --select ml_features --project-dir data_platform/transform --profiles-dir data_platform/transform
+```
+
+### Handoff
+
+* Estado: pendiente
+* Branch real:
+* Comandos corridos:
+* Tablas/modelos creados:
+* Funcion publica principal:
+* Siguiente PR desbloqueado: PR 5
+
+---
+
+## PR 3: `feature/mlflow-tracking`
+
+**Branch:** `feature/mlflow-tracking` desde PR 1 o `develop` si PR 1 ya fue mergeado
+**Owner sugerido:** B
+**Descripcion:** Levantar plataforma de tracking de experimentos y helpers para registrar
+runs, parametros, metricas y artefactos.
+
+### Que implementar
+
+1. Agregar MLflow al stack local:
+   * dependencia en `pyproject.toml`, probablemente dentro de grupo `data` o nuevo grupo `ml`.
+   * servicio `mlflow` en compose existente o compose dedicado.
+   * artifact store local versionado como volumen, no archivos sueltos sin documentar.
+
+2. Crear helpers:
+   * `ml/training/tracking.py`
+   * configurar tracking URI desde env var.
+   * funcion para iniciar run con tags estandar:
+     * `as_of_date`
+     * `git_sha`
+     * `dataset_start`
+     * `dataset_end`
+     * `feature_view`
+     * `model_type`
+
+3. Crear smoke script opcional:
+   * `ml/training/smoke_tracking.py` o comando equivalente.
+   * registra un run de prueba con metricas dummy.
+
+4. Documentar acceso:
+   * URL local de MLflow.
+   * comandos para levantarlo.
+   * como ver runs y metricas.
+
+### ADR asociado
+
+Completar `docs/ADRs/20-experiment-tracking.md`.
+
+Decision recomendada: **MLflow Tracking**.
+
+Alternativas obligatorias:
+
+* MLflow.
+* Weights & Biases.
+* Neptune.
+* tracking casero con CSV/JSON solo como anti-opcion.
+
+### Verificacion
+
+```bash
+uv run pytest tests/test_mlflow_tracking.py
+```
+
+Y manual/demo:
+
+```bash
+docker compose -f docker-compose.ml.yml up -d
+uv run --group ml python -m ml.training.smoke_tracking
+```
+
+Adaptar nombres si se decide no crear grupo `ml` o compose separado.
+
+### Handoff
+
+* Estado: pendiente
+* Branch real:
+* Comandos corridos:
+* URL local MLflow:
+* Funcion publica principal:
+* Siguiente PR desbloqueado: PR 5 y PR 6
+
+---
+
+## PR 4: `feature/prediction-api-contract`
+
+**Branch:** `feature/prediction-api-contract` desde PR 1 o `develop` si PR 1 ya fue mergeado
+**Owner sugerido:** C
+**Descripcion:** Definir el contrato REST de predicciones ML sin esperar a que el modelo
+final exista. El objetivo es que API, tests y demo tengan una superficie estable.
+
+### Que implementar
+
+1. Crear o extender router:
+   * opcion recomendada: `app/predictions/routes.py`.
+   * endpoint sugerido: `POST /predictions`.
+   * endpoint de diagnostico sugerido: `GET /models/current`.
+
+2. Modelos de request/response:
+   * pozo o well id.
+   * `as_of_date`.
+   * horizonte de prediccion si aplica.
+   * prediccion numerica.
+   * metadata del modelo: version/run id/stage.
+   * metadata de features: `feature_as_of_date`.
+
+3. Implementar un adapter temporal:
+   * `ml/inference/service.py`.
+   * mientras PR 6 no exista, puede devolver prediccion baseline controlada.
+   * dejar TODO claro o feature flag para conectar registry real despues.
+
+4. Tests con `tests.TEST_API_KEY`:
+   * request exitoso.
+   * auth requerida.
+   * pozo inexistente o features faltantes.
+   * formato de respuesta estable.
+
+### ADR asociado
+
+No requiere ADR propio salvo que cambie la estrategia de API. Si se decide modificar
+fuertemente el contrato de Fase 1, actualizar o crear ADR especifico.
+
+### Verificacion
+
+```bash
+uv run pytest tests/test_predictions.py
+uv run pytest tests/test_middleware.py
+```
+
+### Handoff
+
+* Estado: pendiente
+* Branch real:
+* Comandos corridos:
+* Endpoints agregados:
+* Contrato request/response:
+* Siguiente PR desbloqueado: PR 6
+
+---
+
+## PR 5: `feature/training-pipeline`
+
+**Branch:** `feature/training-pipeline` desde PR 2 + PR 3 integrados o apilada sobre ambos
+**Owner sugerido:** A
+**Descripcion:** Entrenamiento reproducible para un `as_of_date`, leyendo desde feature
+store y registrando runs reales en MLflow.
+
+### Que implementar
+
+1. Dataset builder:
+   * `ml/training/dataset.py`.
+   * input: `as_of_date`.
+   * output: features `X`, target `y`, metadata de ventana temporal.
+   * garantizar que no haya leakage temporal.
+
+2. Modelo baseline:
+   * usar un modelo simple y defendible.
+   * recomendado: regresion lineal/sklearn o baseline estadistico si se quiere minimizar
+     dependencias.
+   * mantener la API de entrenamiento extensible, pero no sobredisenar.
+
+3. Training entrypoint:
+   * `ml/training/train.py`.
+   * CLI: `--as-of-date YYYY-MM-DD`.
+   * registra params/metrics/artifacts en MLflow.
+   * produce metricas comparables entre runs: MAE, RMSE y cantidad de filas.
+
+4. Tests:
+   * dataset reproducible para la misma fecha.
+   * metricas generadas.
+   * run de MLflow mockeado o smoke local.
+
+### ADR relacionado
+
+Este PR consume ADR-20 y ADR-21. Si se elige una familia de modelo no trivial, agregar
+una seccion en README o un ADR nuevo solo si la decision es clave para la fase.
+
+### Verificacion
+
+```bash
+uv run --group data python -m data_platform.ci.seed_bronze
+uv run --group data dbt build --select silver gold --project-dir data_platform/transform --profiles-dir data_platform/transform
+uv run --group ml python -m ml.training.train --as-of-date 2024-12-31
+uv run --group ml pytest tests/test_training_dataset.py tests/test_training_pipeline.py
+```
+
+### Handoff
+
+* Estado: pendiente
+* Branch real:
+* Comandos corridos:
+* Metricas registradas:
+* Run IDs de ejemplo:
+* Siguiente PR desbloqueado: PR 6 y PR 7
+
+---
+
+## PR 6: `feature/model-registry-promotion`
+
+**Branch:** `feature/model-registry-promotion` desde PR 3 + PR 5 integrados
+**Owner sugerido:** B
+**Descripcion:** Registrar modelos entrenados, validar criterios minimos y conectar la
+API al modelo promovido.
+
+### Que implementar
+
+1. Registry helpers:
+   * `ml/registry/client.py`.
+   * registrar modelo desde run.
+   * consultar modelo actual.
+   * resolver artifact/model URI.
+
+2. Politica de promocion:
+   * `ml/registry/promotion.py`.
+   * criterio minimo: metrica bajo threshold o mejor que modelo actual.
+   * registrar estado: promoted/rejected/staging.
+   * no promover si faltan metricas o validacion.
+
+3. Integracion con inferencia:
+   * `ml/inference/service.py` carga modelo vigente.
+   * endpoint `GET /models/current` devuelve version/run id/metrica/stage.
+   * endpoint `POST /predictions` usa feature store + modelo vigente.
+
+4. Tests:
+   * modelo promovido se resuelve correctamente.
+   * modelo rechazado no reemplaza vigente.
+   * API responde con metadata del modelo.
+   * error claro si no hay modelo promovido.
+
+### ADR asociado
+
+Completar `docs/ADRs/22-model-registry.md`.
+
+Decision recomendada: **MLflow Model Registry**.
+
+Alternativas obligatorias:
+
+* MLflow Model Registry.
+* artefactos versionados en filesystem/storage + metadata en JSON.
+* tabla propia en Postgres.
+
+### Verificacion
+
+```bash
+uv run --group ml pytest tests/test_model_registry.py tests/test_model_promotion.py tests/test_predictions.py
+```
+
+Demo manual:
+
+```bash
+uv run --group ml python -m ml.training.train --as-of-date 2024-12-31
+uv run --group ml python -m ml.registry.promote --run-id <RUN_ID>
+uv run uvicorn app.main:app --reload
+```
+
+### Handoff
+
+* Estado: pendiente
+* Branch real:
+* Comandos corridos:
+* Modelo/version promovido de ejemplo:
+* Endpoint verificado:
+* Siguiente PR desbloqueado: PR 7
+
+---
+
+## PR 7: `feature/retraining-orchestration`
+
+**Branch:** `feature/retraining-orchestration` desde PR 2 + PR 5 + PR 6 integrados
+**Owner sugerido:** C
+**Descripcion:** Orquestar materializacion de features, training, validacion y promocion
+con Dagster, permitiendo retrain manual para un dia dado y schedule recurrente.
+
+### Que implementar
+
+1. Dagster job/assets:
+   * `data_platform/orchestration/assets/ml.py` o modulo equivalente.
+   * asset de feature materialization.
+   * op/asset de training.
+   * op/asset de validation/promotion.
+
+2. Job parametrizable:
+   * `train_model_job`.
+   * config con `as_of_date`.
+   * re-ejecutable para el mismo dia.
+
+3. Schedule:
+   * schedule recurrente para retraining.
+   * documentar frecuencia elegida.
+
+4. Trigger manual:
+   * desde UI de Dagster o CLI.
+   * dejar comando exacto en runbook.
+
+5. Tests:
+   * definitions cargan.
+   * job existe.
+   * config valida.
+   * al menos un smoke test del flujo con fixtures.
+
+### ADR asociado
+
+Completar `docs/ADRs/23-training-orchestration.md`.
+
+Decision recomendada: **Dagster para retraining ML**.
+
+Alternativas obligatorias:
+
+* Dagster.
+* GitHub Actions scheduled workflow.
+* Airflow.
+
+### Verificacion
+
+```bash
+uv run --group data dagster definitions validate -m data_platform.orchestration
+uv run --group ml pytest tests/test_ml_orchestration.py
+```
+
+Demo manual:
+
+```bash
+docker compose --env-file .env.data -f docker-compose.data.yml up -d
+# abrir Dagster y disparar train_model_job con as_of_date
+```
+
+### Handoff
+
+* Estado: pendiente
+* Branch real:
+* Comandos corridos:
+* Job/schedule creado:
+* Forma de trigger manual:
+* Siguiente PR desbloqueado: PR 8 y PR 9
+
+---
+
+## PR 8: `feature/ml-pipeline-cicd`
+
+**Branch:** `feature/ml-pipeline-cicd` desde PR 5 + PR 6 + PR 7 integrados
+**Owner sugerido:** A
+**Descripcion:** Validar automaticamente los pipelines de ML en CI/CD sin requerir un
+servicio live de produccion.
+
+### Que implementar
+
+1. Extender `.github/workflows/ci.yml`:
+   * instalar dependencias ML.
+   * correr tests de feature store/training/registry.
+   * validar Dagster definitions.
+   * smoke test de training con dataset chico o fixtures.
+
+2. Si hace falta, agregar workflow separado:
+   * `.github/workflows/ml-pipeline.yml`.
+   * mantenerlo chico y reproducible.
+
+3. Asegurar que no dependa de secretos reales:
+   * usar Postgres service container.
+   * usar tracking URI local temporal.
+   * artifact store temporal dentro del runner.
+
+4. Documentar equivalentes locales:
+   * comandos para correr los mismos checks fuera de GitHub.
+
+### ADR asociado
+
+Completar `docs/ADRs/24-ml-pipeline-cicd.md`.
+
+Decision recomendada: **GitHub Actions como CI/CD de pipelines ML**.
+
+Alternativas obligatorias:
+
+* GitHub Actions.
+* deploy/manual local.
+* Dagster Cloud u otro scheduler gestionado.
+* Jenkins/GitLab CI si quieren comparar generico.
+
+### Verificacion
+
+```bash
+uv run pytest
+uv run --group data dagster definitions validate -m data_platform.orchestration
+uv run --group ml pytest tests/test_feature_store.py tests/test_training_pipeline.py tests/test_model_registry.py
+```
+
+Ademas, verificar el workflow en GitHub cuando se abra el PR.
+
+### Handoff
+
+* Estado: pendiente
+* Branch real:
+* Comandos corridos:
+* Workflows modificados:
+* Checks esperados en PR:
+* Siguiente PR desbloqueado: PR 9
+
+---
+
+## PR 9: `feature/phase3-docs-demo`
+
+**Branch:** `feature/phase3-docs-demo` desde todos los PRs previos integrados
+**Owner sugerido:** B
+**Descripcion:** Cierre de documentacion, runbook de demo y guion del video de 5 a 10
+minutos.
+
+### Que implementar
+
+1. Completar `README.md`:
+   * arquitectura completa.
+   * herramientas usadas.
+   * comandos de quickstart.
+   * como correr API + MLflow + Dagster + feature store.
+   * como hacer retrain para un dia dado.
+
+2. Crear runbook:
+   * `docs/runbooks/ml-engineer.md`.
+   * levantar stack.
+   * materializar features.
+   * entrenar modelo.
+   * ver runs en MLflow.
+   * promover o ver modelo vigente.
+   * llamar API.
+   * disparar retrain.
+
+3. Crear guion/evidencia para video:
+   * `docs/fase-3-video.md`.
+   * seccion "que mostrar".
+   * seccion "que decir".
+   * comandos exactos.
+   * capturas sugeridas: MLflow runs, Dagster job, API calls.
+
+4. Revisar todos los ADRs:
+   * confirmar que cada uno compara alternativas.
+   * confirmar que no son solo descripcion del camino tomado.
+   * agregar "Confirmacion" con archivos reales implementados.
+
+### Verificacion
+
+```bash
+uv run pytest
+uv run --group data dagster definitions validate -m data_platform.orchestration
+uv run pre-commit run --all-files
+```
+
+Demo completa esperada:
+
+```bash
+docker compose --env-file .env.data -f docker-compose.data.yml up -d
+docker compose -f docker-compose.ml.yml up -d
+uv run --group data python -m data_platform.ci.seed_bronze
+uv run --group data dbt build --select silver gold --project-dir data_platform/transform --profiles-dir data_platform/transform
+uv run --group ml python -m ml.training.train --as-of-date 2024-12-31
+uv run --group ml python -m ml.registry.promote --run-id <RUN_ID>
+uv run uvicorn app.main:app --reload
+```
+
+Despues llamar API con `curl`, PowerShell o `httpx` usando `X-API-Key`.
+
+### Handoff
+
+* Estado: pendiente
+* Branch real:
+* Comandos corridos:
+* Evidencia lista para video:
+* Riesgos restantes:
+* Entrega final:
+
+---
+
+## Detalle de ADRs de Fase 3
+
+Todos los ADRs deben mantener el estilo existente:
+
+* `status`
+* `date`
+* `decision-makers`
+* contexto y problema
+* impulsores de decision
+* opciones consideradas
+* resultado de decision
+* consecuencias buenas y malas
+* confirmacion con archivos reales
+
+### ADR-20: Experiment tracking
+
+**Archivo:** `docs/ADRs/20-experiment-tracking.md`
+
+**Problema:** Los ML Engineers necesitan ver runs de entrenamiento, parametros, metricas
+y artefactos para comparar experimentos y reproducir resultados.
+
+**Drivers:**
+
+* UI local para ver runs.
+* Registro de parametros, metricas y artifacts.
+* Bajo costo operativo.
+* Integracion posible con registry.
+* Buen encaje con demo de la materia.
+
+**Opciones a comparar:**
+
+* **MLflow Tracking:** local, open source, tracking + artifacts + registry.
+* **Weights & Biases:** excelente UI gestionada, pero requiere servicio externo/cuenta.
+* **Neptune:** fuerte para equipos ML, pero suma vendor externo.
+* **CSV/JSON propio:** simple, pero pobre para comparacion y reproducibilidad.
+
+**Decision recomendada:** MLflow Tracking.
+
+**Confirmacion esperada:** compose/servicio MLflow, helpers en `ml/training/tracking.py`,
+training registrando metricas reales, tests o smoke script.
+
+### ADR-21: Feature store
+
+**Archivo:** `docs/ADRs/21-feature-store.md`
+
+**Problema:** Las features usadas por entrenamiento e inferencia deben persistirse y
+consultarse de forma consistente para evitar skew entre training y serving.
+
+**Drivers:**
+
+* Persistencia.
+* Reuso por training e inferencia.
+* Reprocesamiento por fecha.
+* No leakage temporal.
+* Integracion con Postgres/dbt/Dagster ya existentes.
+
+**Opciones a comparar:**
+
+* **Postgres como feature store:** esquema/tablas persistidas, materializadas por dbt o
+  Dagster.
+* **Feast:** feature store dedicado, mas completo, pero agrega complejidad operativa.
+* **Parquet versionado:** simple para batch, mas incomodo para API online.
+
+**Decision recomendada:** Postgres como feature store persistido.
+
+**Confirmacion esperada:** modelos/tablas de features, codigo `ml/features/store.py`,
+tests de idempotencia y lookup por fecha.
+
+### ADR-22: Model registry
+
+**Archivo:** `docs/ADRs/22-model-registry.md`
+
+**Problema:** La API necesita resolver un modelo vigente/promovido, y el equipo necesita
+trazabilidad entre run, metricas, artefacto y version servida.
+
+**Drivers:**
+
+* Versionado de modelos.
+* Relacion modelo-run-metricas.
+* Promocion/rechazo.
+* Integracion con API.
+* Evitar inventar registry casero.
+
+**Opciones a comparar:**
+
+* **MLflow Model Registry:** integrado con tracking y artifacts.
+* **Artefactos versionados + JSON:** simple, pero con poca trazabilidad y validacion.
+* **Tabla propia en Postgres:** control total, pero alto riesgo de reinventar mal.
+
+**Decision recomendada:** MLflow Model Registry.
+
+**Confirmacion esperada:** helpers en `ml/registry/`, CLI o funcion de promocion, endpoint
+`GET /models/current`, tests de modelo promovido/rechazado.
+
+### ADR-23: Training orchestration
+
+**Archivo:** `docs/ADRs/23-training-orchestration.md`
+
+**Problema:** El entrenamiento debe repetirse para un dia dado y ejecutarse de manera
+recurrente/automatica.
+
+**Drivers:**
+
+* Parametro `as_of_date`.
+* Trigger manual demostrable.
+* Schedule recurrente.
+* Observabilidad de runs.
+* Reuso de Dagster ya existente.
+
+**Opciones a comparar:**
+
+* **Dagster:** assets/jobs/schedules, UI local, ya presente en repo.
+* **GitHub Actions cron:** simple para schedules, pobre para observabilidad de datos y
+  trigger parametrico.
+* **Airflow:** maduro, pero agrega stack paralelo innecesario.
+
+**Decision recomendada:** Dagster.
+
+**Confirmacion esperada:** `train_model_job`, schedule, config por `as_of_date`,
+validacion de definitions y runbook de trigger manual.
+
+### ADR-24: ML pipeline CI/CD
+
+**Archivo:** `docs/ADRs/24-ml-pipeline-cicd.md`
+
+**Problema:** Los pipelines de procesamiento/ML deben validarse y desplegarse mediante
+CI/CD, aunque la entrega no tenga servicio live en produccion.
+
+**Drivers:**
+
+* Checks automaticos por PR.
+* No depender de secretos reales.
+* Validar dbt, Dagster, feature store, training y registry.
+* Mantener consistencia con CI existente.
+
+**Opciones a comparar:**
+
+* **GitHub Actions:** ya usado por el repo, soporta service containers y jobs por PR.
+* **Deploy manual/local:** simple, pero no cumple automatizacion.
+* **Dagster Cloud u orquestador gestionado:** potente, pero excede alcance/costo.
+* **Jenkins/GitLab CI:** validos, pero no estan integrados al repo actual.
+
+**Decision recomendada:** GitHub Actions.
+
+**Confirmacion esperada:** jobs CI para ML, smoke training, validate Dagster definitions,
+tests de API/registry y documentacion de comandos locales equivalentes.
+
+---
+
+## Checklist de video final
+
+El video debe durar entre 5 y 10 minutos. No mostrar solo slides: demostrar integracion
+real del proceso ML con la API.
+
+Orden recomendado:
+
+1. Arquitectura completa en `README.md`.
+2. Feature store persistido en Postgres.
+3. MLflow con al menos dos runs y metricas distintas.
+4. Modelo registrado/promovido.
+5. API respondiendo predicciones con metadata del modelo.
+6. Trigger manual de retrain en Dagster para un `as_of_date`.
+7. Nuevo run en MLflow despues del retrain.
+8. Cierre: valor agregado en reproducibilidad, trazabilidad y reduccion de skew.
+
+Evidencia minima antes de grabar:
+
+* Captura o demo de MLflow con multiples runs.
+* Captura o demo de Dagster con job de retraining.
+* Llamadas API con dos condiciones distintas.
+* Comando de retrain para un dia dado.
+* README y ADRs visibles.
+
+## Comandos base de referencia
+
+Estos comandos deben ajustarse si los PRs cambian nombres de grupos o compose files.
+
+```bash
+uv sync
+uv sync --group data
+uv run pytest
+uv run pre-commit run --all-files
+uv run --group data python -m data_platform.ci.seed_bronze
+uv run --group data dbt build --select silver gold --project-dir data_platform/transform --profiles-dir data_platform/transform
+uv run --group data dagster definitions validate -m data_platform.orchestration
+docker compose --env-file .env.data -f docker-compose.data.yml up -d
+```
+
+Comandos esperados a incorporar cuando existan PRs ML:
+
+```bash
+uv sync --group ml
+docker compose -f docker-compose.ml.yml up -d
+uv run --group ml python -m ml.training.train --as-of-date 2024-12-31
+uv run --group ml python -m ml.registry.promote --run-id <RUN_ID>
+uv run uvicorn app.main:app --reload
+```
+
+## Anti-patrones a evitar
+
+* ADRs sin alternativas reales.
+* Feature store que solo existe en memoria durante training.
+* API que recalcula features de una forma distinta al training.
+* Training sin `as_of_date`.
+* Runs sin metricas comparables.
+* Modelo servido sin version/run id visible.
+* Retrain que solo sea un comando manual sin schedule ni orquestacion.
+* CI que solo corre tests de API y no valida pipelines ML.
+* Documentacion que promete produccion live cuando la consigna dice que no se entrega
+  servicio live en produccion.

--- a/ml/__init__.py
+++ b/ml/__init__.py
@@ -1,0 +1,1 @@
+"""Machine learning engineering components for the prediction service."""

--- a/ml/config.py
+++ b/ml/config.py
@@ -1,0 +1,28 @@
+"""Shared configuration for the Phase 3 ML Engineering stack."""
+
+from dataclasses import dataclass
+from os import getenv
+
+
+@dataclass(frozen=True)
+class MLSettings:
+    """Runtime settings shared by training, registry, features, and inference."""
+
+    mlflow_tracking_uri: str
+    mlflow_experiment_name: str
+    mlflow_model_name: str
+    feature_store_schema: str
+
+
+def get_ml_settings() -> MLSettings:
+    """Load ML settings from environment variables with local defaults."""
+
+    return MLSettings(
+        mlflow_tracking_uri=getenv("MLFLOW_TRACKING_URI", "http://localhost:5000"),
+        mlflow_experiment_name=getenv(
+            "MLFLOW_EXPERIMENT_NAME",
+            "well-production-forecast",
+        ),
+        mlflow_model_name=getenv("MLFLOW_MODEL_NAME", "well-production-forecast"),
+        feature_store_schema=getenv("ML_FEATURE_STORE_SCHEMA", "ml_features"),
+    )

--- a/ml/features/__init__.py
+++ b/ml/features/__init__.py
@@ -1,0 +1,1 @@
+"""Feature store access and materialization helpers."""

--- a/ml/inference/__init__.py
+++ b/ml/inference/__init__.py
@@ -1,0 +1,1 @@
+"""Inference services used by the API layer."""

--- a/ml/registry/__init__.py
+++ b/ml/registry/__init__.py
@@ -1,0 +1,1 @@
+"""Model registry clients and promotion policy helpers."""

--- a/ml/training/__init__.py
+++ b/ml/training/__init__.py
@@ -1,0 +1,1 @@
+"""Training dataset, tracking, and model training helpers."""

--- a/tests/test_ml_config.py
+++ b/tests/test_ml_config.py
@@ -1,0 +1,41 @@
+"""Tests for the shared ML Engineering configuration."""
+
+import pytest
+
+from ml.config import MLSettings, get_ml_settings
+
+
+def test_get_ml_settings_uses_phase3_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return the shared Phase 3 defaults when no env vars are set."""
+
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    monkeypatch.delenv("MLFLOW_EXPERIMENT_NAME", raising=False)
+    monkeypatch.delenv("MLFLOW_MODEL_NAME", raising=False)
+    monkeypatch.delenv("ML_FEATURE_STORE_SCHEMA", raising=False)
+
+    settings = get_ml_settings()
+
+    assert settings == MLSettings(
+        mlflow_tracking_uri="http://localhost:5000",
+        mlflow_experiment_name="well-production-forecast",
+        mlflow_model_name="well-production-forecast",
+        feature_store_schema="ml_features",
+    )
+
+
+def test_get_ml_settings_allows_environment_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allow local and CI environments to override ML settings."""
+
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://mlflow.local:5000")
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "custom-experiment")
+    monkeypatch.setenv("MLFLOW_MODEL_NAME", "custom-model")
+    monkeypatch.setenv("ML_FEATURE_STORE_SCHEMA", "custom_features")
+
+    settings = get_ml_settings()
+
+    assert settings.mlflow_tracking_uri == "http://mlflow.local:5000"
+    assert settings.mlflow_experiment_name == "custom-experiment"
+    assert settings.mlflow_model_name == "custom-model"
+    assert settings.feature_store_schema == "custom_features"


### PR DESCRIPTION
## Resumen

PR 1 de Fase 3. Deja la base de ML Engineering para que el equipo pueda trabajar los siguientes PRs en paralelo sin reconstruir contexto.

Incluye:
- plan vivo de Fase 3 en `docs/planes/fase-3.md`, con PRs, owners sugeridos, dependencias y handoff por agente
- ADRs comparativos para las decisiones clave de Fase 3: experiment tracking, feature store, model registry, training orchestration y ML CI/CD
- scaffolding del paquete `ml/` y configuración compartida en `ml/config.py`
- tests del harness de configuración ML
- actualización de README e índice de documentación
- ignore de caches locales usados por la verificación (`.uv-cache/`, `.pre-commit-cache/`)

## Validación

- `uv run pytest` -> 133 passed, 20 skipped
- `uv run black --config .pre-commit/.black.toml --check ml tests/test_ml_config.py`
- `uv run flake8 --config .pre-commit/.flake8 ml tests/test_ml_config.py`
- `uv run pylint --rcfile .pre-commit/.pylintrc --persistent=n ml tests/test_ml_config.py`
- `uv run mypy --config-file .pre-commit/mypy.ini ml tests/test_ml_config.py`

## Notas

`uv run pre-commit run --all-files` no pudo completarse localmente porque el entorno no pudo descargar hooks desde GitHub (`https://github.com/psf/black/`). Los checks equivalentes sobre los archivos Python tocados se corrieron directamente y quedaron verdes.

## Siguiente paso

Una vez mergeado este PR, quedan desbloqueados:
- PR 2: `feature/ml-feature-store`
- PR 3: `feature/mlflow-tracking`
- PR 4: `feature/prediction-api-contract`