### PR TITLE
Fase 3 PR2: feature store persistido

### DIFF
--- a/data_platform/transform/models/ml_features/_ml_features__models.yml
+++ b/data_platform/transform/models/ml_features/_ml_features__models.yml
@@ -1,0 +1,64 @@
+version: 2
+
+models:
+  - name: well_monthly_features
+    description: "Feature store mensual por pozo y fecha de corte para training e inferencia."
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - well_id
+              - as_of_date
+    columns:
+      - name: well_id
+        description: "Identificador natural del pozo."
+        data_tests:
+          - not_null
+      - name: as_of_date
+        description: "Fecha de corte usada para construir las features sin leakage temporal."
+        data_tests:
+          - not_null
+      - name: gas_production_current
+        description: "Produccion de gas del periodo de corte."
+        data_tests:
+          - not_null
+      - name: gas_production_avg_3m
+        description: "Media movil de gas en los ultimos tres meses disponibles."
+        data_tests:
+          - not_null
+      - name: gas_production_avg_6m
+        description: "Media movil de gas en los ultimos seis meses disponibles."
+        data_tests:
+          - not_null
+      - name: gas_production_trend_3m
+        description: "Diferencia entre produccion actual de gas y media movil de tres meses."
+        data_tests:
+          - not_null
+      - name: oil_production_current
+        description: "Produccion de petroleo del periodo de corte."
+        data_tests:
+          - not_null
+      - name: water_production_current
+        description: "Produccion de agua del periodo de corte."
+        data_tests:
+          - not_null
+      - name: producing_days_available
+        description: "Dias de produccion disponibles en el periodo de corte."
+        data_tests:
+          - not_null
+      - name: production_months_available
+        description: "Cantidad de meses historicos usados hasta la fecha de corte."
+        data_tests:
+          - not_null
+      - name: formation
+        description: "Formacion productiva vigente del pozo."
+        data_tests:
+          - not_null
+      - name: basin
+        description: "Cuenca vigente del pozo."
+        data_tests:
+          - not_null
+      - name: resource_type
+        description: "Tipo de recurso vigente del pozo."
+        data_tests:
+          - not_null

--- a/data_platform/transform/models/ml_features/well_monthly_features.sql
+++ b/data_platform/transform/models/ml_features/well_monthly_features.sql
@@ -1,0 +1,102 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key=['well_id', 'as_of_date'],
+    schema='ml_features'
+) }}
+
+with feature_dates as (
+
+    select distinct
+        id_pozo as well_id,
+        periodo as as_of_date
+    from {{ ref('fct_produccion') }}
+
+    {% if is_incremental() %}
+      where (
+        _loaded_at > (select max(_loaded_at) from {{ this }})
+        {% if var('reprocess_period', none) %}
+        or periodo = '{{ var("reprocess_period") }}'::date
+        {% endif %}
+      )
+    {% endif %}
+
+),
+
+history as (
+
+    select
+        id_pozo as well_id,
+        periodo,
+        prod_gas,
+        prod_petroleo,
+        prod_agua,
+        dias_produccion
+    from {{ ref('fct_produccion') }}
+
+),
+
+windowed as (
+
+    select
+        feature_dates.well_id,
+        feature_dates.as_of_date,
+        max(history.prod_gas) filter (
+            where history.periodo = feature_dates.as_of_date
+        ) as gas_production_current,
+        avg(history.prod_gas) filter (
+            where history.periodo >= feature_dates.as_of_date - interval '2 months'
+        ) as gas_production_avg_3m,
+        avg(history.prod_gas) filter (
+            where history.periodo >= feature_dates.as_of_date - interval '5 months'
+        ) as gas_production_avg_6m,
+        max(history.prod_petroleo) filter (
+            where history.periodo = feature_dates.as_of_date
+        ) as oil_production_current,
+        max(history.prod_agua) filter (
+            where history.periodo = feature_dates.as_of_date
+        ) as water_production_current,
+        max(history.dias_produccion) filter (
+            where history.periodo = feature_dates.as_of_date
+        ) as producing_days_available,
+        count(distinct history.periodo) as production_months_available
+    from feature_dates
+    inner join history
+        on history.well_id = feature_dates.well_id
+       and history.periodo <= feature_dates.as_of_date
+    group by
+        feature_dates.well_id,
+        feature_dates.as_of_date
+
+),
+
+well_attributes as (
+
+    select
+        id_pozo as well_id,
+        formacion_productiva as formation,
+        cuenca as basin,
+        tipo_recurso as resource_type
+    from {{ ref('dim_pozo') }}
+    where is_current
+
+)
+
+select
+    windowed.well_id,
+    windowed.as_of_date,
+    windowed.gas_production_current,
+    windowed.gas_production_avg_3m,
+    windowed.gas_production_avg_6m,
+    windowed.gas_production_current - windowed.gas_production_avg_3m
+        as gas_production_trend_3m,
+    windowed.oil_production_current,
+    windowed.water_production_current,
+    windowed.producing_days_available,
+    windowed.production_months_available,
+    well_attributes.formation,
+    well_attributes.basin,
+    well_attributes.resource_type
+from windowed
+inner join well_attributes
+    on windowed.well_id = well_attributes.well_id

--- a/docs/ADRs/21-feature-store.md
+++ b/docs/ADRs/21-feature-store.md
@@ -1,8 +1,8 @@
 # ADR-21: Feature store persistido para entrenamiento e inferencia
 
 ```
-status: Propuesto
-date: 2026-06-25
+status: Aceptado
+date: 2026-06-26
 decision-makers: Equipo de Desarrollo
 ```
 
@@ -64,3 +64,20 @@ Confirmar en PR 2 con modelos/tablas persistidas bajo `ml_features`, codigo de l
 `ml/features/store.py`, tests de idempotencia, lookup por fecha y ausencia de leakage
 temporal.
 
+## Confirmacion PR 2
+
+PR 2 confirma la decision con:
+
+* modelo dbt incremental `ml_features.well_monthly_features`, materializado con merge
+  idempotente por `well_id` + `as_of_date`;
+* features iniciales de produccion reciente, medias moviles, tendencia simple, meses/dias
+  disponibles y atributos estables del pozo desde gold;
+* join historico limitado a registros con `periodo <= as_of_date` para evitar leakage
+  temporal;
+* API tipada en `ml/features/store.py` con `FeatureRow`, `FeatureStore`,
+  `InMemoryFeatureRepository` y `PostgresFeatureRepository`;
+* error controlado `FeatureNotFoundError` cuando no hay features disponibles para el pozo
+  y fecha solicitados.
+
+La integracion Dagster queda para los PRs de orquestacion/retraining; este PR deja la
+materializacion disponible via dbt y el lookup Python sobre Postgres.

--- a/docs/planes/fase-3.md
+++ b/docs/planes/fase-3.md
@@ -123,7 +123,7 @@ La asignacion es flexible, pero el total queda balanceado: 3 PRs por persona.
 | PR | Branch | Owner sugerido | Depende de | Estado | Entrega principal |
 |----|--------|----------------|------------|--------|-------------------|
 | 1 | `feature/mlops-foundation` | C | `develop` | listo para review | estructura ML + ADRs iniciales + README arquitectura base |
-| 2 | `feature/ml-feature-store` | A | PR 1 | pendiente | feature store persistido y materializacion |
+| 2 | `feature/ml-feature-store` | A | PR 1 | listo para review | feature store persistido y materializacion |
 | 3 | `feature/mlflow-tracking` | B | PR 1 | pendiente | MLflow local + tracking helpers |
 | 4 | `feature/prediction-api-contract` | C | PR 1 | pendiente | contrato API de prediccion y tests base |
 | 5 | `feature/training-pipeline` | A | PR 2 + PR 3 | pendiente | entrenamiento reproducible por `as_of_date` |
@@ -281,12 +281,25 @@ uv run --group data dbt build --select ml_features --project-dir data_platform/t
 
 ### Handoff
 
-* Estado: pendiente
-* Branch real:
+* Estado: listo para review
+* Branch real: `feature/ml-feature-store`
 * Comandos corridos:
+  * `$env:UV_CACHE_DIR='.uv-cache'; $env:PYTEST_ADDOPTS='-p no:cacheprovider'; uv run pytest tests/test_feature_store.py` -> RED inicial: `ModuleNotFoundError: No module named 'ml.features.store'`
+  * `$env:UV_CACHE_DIR='.uv-cache'; $env:PYTEST_ADDOPTS='-p no:cacheprovider'; uv run pytest tests/test_feature_store.py` -> RED dbt: 2 failures por `FileNotFoundError` de `data_platform/transform/models/ml_features/well_monthly_features.sql`
+  * `$env:UV_CACHE_DIR='.uv-cache'; $env:PYTEST_ADDOPTS='-p no:cacheprovider'; uv run pytest tests/test_feature_store.py` -> 7 passed
+  * `$env:UV_CACHE_DIR='.uv-cache'; uv run black --config .pre-commit/.black.toml --check ml/features/store.py tests/test_feature_store.py` -> passed
+  * `$env:UV_CACHE_DIR='.uv-cache'; uv run flake8 --config .pre-commit/.flake8 ml/features/store.py tests/test_feature_store.py` -> passed
+  * `$env:UV_CACHE_DIR='.uv-cache'; uv run pylint --rcfile .pre-commit/.pylintrc --persistent=n ml/features/store.py tests/test_feature_store.py` -> 10.00/10
+  * `$env:UV_CACHE_DIR='.uv-cache'; uv run mypy --config-file .pre-commit/mypy.ini ml/features/store.py tests/test_feature_store.py` -> success
+  * `$env:UV_CACHE_DIR='.uv-cache'; uv run --group data dbt parse --project-dir data_platform/transform --profiles-dir data_platform/transform` -> passed con warning existente de config path `models.ingenieria_software.bronze` sin recursos
 * Tablas/modelos creados:
-* Funcion publica principal:
-* Siguiente PR desbloqueado: PR 5
+  * `data_platform/transform/models/ml_features/well_monthly_features.sql`
+  * `data_platform/transform/models/ml_features/_ml_features__models.yml`
+* Funcion publica principal: `FeatureStore.get_features()` con `PostgresFeatureRepository.lookup_features()`
+* Decisiones/desviaciones:
+  * Materializacion PR2 via dbt incremental; Dagster hook queda para PR7/orquestacion.
+  * No se ejecuto `dbt build` contra warehouse live para evitar mutaciones fuera del alcance de los tests locales.
+* Siguiente PR desbloqueado: PR 5 cuando PR 3 tambien este integrado
 
 ---
 

--- a/ml/features/store.py
+++ b/ml/features/store.py
@@ -1,0 +1,201 @@
+"""Feature store lookup primitives for Phase 3 ML inference and training."""
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+import re
+from typing import Any, Protocol
+
+from ml.config import get_ml_settings
+
+
+_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class FeatureRow:  # pylint: disable=too-many-instance-attributes
+    """Point-in-time well features materialized in the feature store."""
+
+    well_id: str
+    as_of_date: date
+    gas_production_current: Decimal
+    gas_production_avg_3m: Decimal
+    gas_production_avg_6m: Decimal
+    gas_production_trend_3m: Decimal
+    oil_production_current: Decimal
+    water_production_current: Decimal
+    producing_days_available: int
+    production_months_available: int
+    formation: str
+    basin: str
+    resource_type: str
+
+
+class FeatureNotFoundError(LookupError):
+    """Raised when no point-in-time feature row exists for a well/date."""
+
+    def __init__(self, *, well_id: str, as_of_date: date, schema: str) -> None:
+        super().__init__(
+            "No feature row found for "
+            f"well_id={well_id!r} as_of_date={as_of_date.isoformat()} "
+            f"in schema {schema!r}"
+        )
+
+
+class FeatureRepository(Protocol):
+    """Repository contract implemented by local fakes and Postgres storage."""
+
+    def lookup_features(self, well_id: str, as_of_date: date) -> FeatureRow | None:
+        """Return the latest feature row available at or before ``as_of_date``."""
+
+
+class FeatureStore:
+    """High-level feature lookup API with controlled domain errors."""
+
+    def __init__(
+        self, repository: FeatureRepository, *, schema: str | None = None
+    ) -> None:
+        self._repository = repository
+        self._schema = schema or get_ml_settings().feature_store_schema
+
+    def get_features(self, well_id: str, as_of_date: date) -> FeatureRow:
+        """Return point-in-time features for a well and cutoff date."""
+
+        row = self._repository.lookup_features(well_id, as_of_date)
+        if row is None:
+            raise FeatureNotFoundError(
+                well_id=well_id, as_of_date=as_of_date, schema=self._schema
+            )
+        return row
+
+
+class InMemoryFeatureRepository:
+    """Deterministic repository useful for unit tests and local prototyping."""
+
+    def __init__(self, rows: Iterable[FeatureRow]) -> None:
+        self._rows_by_grain: dict[tuple[str, date], FeatureRow] = {}
+        for row in rows:
+            self._rows_by_grain[(row.well_id, row.as_of_date)] = row
+
+    def lookup_features(self, well_id: str, as_of_date: date) -> FeatureRow | None:
+        """Return the latest row for ``well_id`` without crossing the cutoff."""
+
+        candidates = [
+            row
+            for (candidate_well_id, candidate_date), row in self._rows_by_grain.items()
+            if candidate_well_id == well_id and candidate_date <= as_of_date
+        ]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda row: row.as_of_date)
+
+
+class PostgresFeatureRepository:
+    """Postgres-backed feature repository over ``ml_features`` dbt models."""
+
+    def __init__(
+        self,
+        connection_factory: Callable[[], Any],
+        *,
+        schema: str | None = None,
+    ) -> None:
+        self._connection_factory = connection_factory
+        self._schema = schema or get_ml_settings().feature_store_schema
+        self._qualified_table = (
+            f"{_validate_identifier(self._schema)}.well_monthly_features"
+        )
+
+    def lookup_features(self, well_id: str, as_of_date: date) -> FeatureRow | None:
+        """Read the latest persisted feature row for the requested cutoff."""
+
+        connection = self._connection_factory()
+        with _open_cursor(connection) as cursor:
+            cursor.execute(
+                f"""
+                select
+                    well_id,
+                    as_of_date,
+                    gas_production_current,
+                    gas_production_avg_3m,
+                    gas_production_avg_6m,
+                    gas_production_trend_3m,
+                    oil_production_current,
+                    water_production_current,
+                    producing_days_available,
+                    production_months_available,
+                    formation,
+                    basin,
+                    resource_type
+                from {self._qualified_table}
+                where well_id = %s
+                  and as_of_date <= %s
+                order by as_of_date desc
+                limit 1
+                """,
+                (well_id, as_of_date),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_from_mapping(row)
+
+
+def _validate_identifier(identifier: str) -> str:
+    if not _IDENTIFIER_PATTERN.fullmatch(identifier):
+        raise ValueError(f"Invalid PostgreSQL identifier: {identifier!r}")
+    return identifier
+
+
+def _open_cursor(connection: Any) -> Any:
+    # Import lazily so default app/test installs do not require the data group.
+    # pylint: disable=import-outside-toplevel
+    try:
+        from psycopg2.extras import RealDictCursor
+    except ImportError:
+        return connection.cursor()
+
+    try:
+        return connection.cursor(cursor_factory=RealDictCursor)
+    except TypeError:
+        return connection.cursor()
+
+
+def _row_from_mapping(row: Mapping[str, object]) -> FeatureRow:
+    return FeatureRow(
+        well_id=str(row["well_id"]),
+        as_of_date=_as_date(row["as_of_date"]),
+        gas_production_current=_as_decimal(row["gas_production_current"]),
+        gas_production_avg_3m=_as_decimal(row["gas_production_avg_3m"]),
+        gas_production_avg_6m=_as_decimal(row["gas_production_avg_6m"]),
+        gas_production_trend_3m=_as_decimal(row["gas_production_trend_3m"]),
+        oil_production_current=_as_decimal(row["oil_production_current"]),
+        water_production_current=_as_decimal(row["water_production_current"]),
+        producing_days_available=_as_int(row["producing_days_available"]),
+        production_months_available=_as_int(row["production_months_available"]),
+        formation=str(row["formation"]),
+        basin=str(row["basin"]),
+        resource_type=str(row["resource_type"]),
+    )
+
+
+def _as_date(value: object) -> date:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        return date.fromisoformat(value)
+    raise TypeError(f"Expected date-compatible value, got {type(value).__name__}")
+
+
+def _as_decimal(value: object) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _as_int(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (str, Decimal)):
+        return int(value)
+    raise TypeError(f"Expected int-compatible value, got {type(value).__name__}")

--- a/tests/test_feature_store.py
+++ b/tests/test_feature_store.py
@@ -1,0 +1,187 @@
+"""Tests for the Phase 3 feature store foundation."""
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ml.features.store import (
+    FeatureNotFoundError,
+    FeatureRow,
+    FeatureStore,
+    InMemoryFeatureRepository,
+    PostgresFeatureRepository,
+)
+
+
+def _feature_row(
+    well_id: str,
+    as_of_date: date,
+    production_current: Decimal,
+) -> FeatureRow:
+    return FeatureRow(
+        well_id=well_id,
+        as_of_date=as_of_date,
+        gas_production_current=production_current,
+        gas_production_avg_3m=Decimal("90.0"),
+        gas_production_avg_6m=Decimal("85.0"),
+        gas_production_trend_3m=Decimal("-2.5"),
+        oil_production_current=Decimal("12.0"),
+        water_production_current=Decimal("4.0"),
+        producing_days_available=28,
+        production_months_available=6,
+        formation="Vaca Muerta",
+        basin="Neuquina",
+        resource_type="Shale",
+    )
+
+
+def test_get_features_returns_latest_row_at_or_before_as_of_date() -> None:
+    """Return the point-in-time features available at the requested cutoff."""
+
+    repository = InMemoryFeatureRepository(
+        [
+            _feature_row("POZO-001", date(2024, 1, 1), Decimal("100.0")),
+            _feature_row("POZO-001", date(2024, 3, 1), Decimal("75.0")),
+            _feature_row("POZO-001", date(2024, 5, 1), Decimal("50.0")),
+        ]
+    )
+    store = FeatureStore(repository)
+
+    row = store.get_features("POZO-001", date(2024, 4, 15))
+
+    assert row.well_id == "POZO-001"
+    assert row.as_of_date == date(2024, 3, 1)
+    assert row.gas_production_current == Decimal("75.0")
+
+
+def test_get_features_does_not_use_future_rows() -> None:
+    """Do not leak features materialized after the requested cutoff."""
+
+    repository = InMemoryFeatureRepository(
+        [_feature_row("POZO-001", date(2024, 5, 1), Decimal("50.0"))]
+    )
+    store = FeatureStore(repository)
+
+    with pytest.raises(FeatureNotFoundError, match="POZO-001.*2024-04-01"):
+        store.get_features("POZO-001", date(2024, 4, 1))
+
+
+def test_get_features_raises_clear_error_when_missing() -> None:
+    """Expose a controlled domain error when features are absent."""
+
+    store = FeatureStore(InMemoryFeatureRepository([]))
+
+    with pytest.raises(FeatureNotFoundError) as exc_info:
+        store.get_features("POZO-404", date(2024, 4, 1))
+
+    assert "POZO-404" in str(exc_info.value)
+    assert "2024-04-01" in str(exc_info.value)
+    assert "ml_features" in str(exc_info.value)
+
+
+def test_in_memory_repository_replaces_duplicate_well_date_rows() -> None:
+    """Keep rematerialization idempotent for the same well/date grain."""
+
+    repository = InMemoryFeatureRepository(
+        [
+            _feature_row("POZO-001", date(2024, 3, 1), Decimal("75.0")),
+            _feature_row("POZO-001", date(2024, 3, 1), Decimal("80.0")),
+        ]
+    )
+
+    row = repository.lookup_features("POZO-001", date(2024, 3, 1))
+
+    assert row is not None
+    assert row.gas_production_current == Decimal("80.0")
+
+
+def test_postgres_repository_uses_configured_schema_and_cutoff_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Build the Postgres lookup against the configured feature schema."""
+
+    captured: dict[str, Any] = {}
+
+    class Cursor:
+        """Minimal DB-API cursor fake for query inspection."""
+
+        def __enter__(self) -> "Cursor":
+            """Return the cursor context manager value."""
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            """Close the cursor context manager."""
+            return None
+
+        def execute(self, query: str, params: tuple[str, date]) -> None:
+            """Capture the SQL query and params sent by the repository."""
+            captured["query"] = query
+            captured["params"] = params
+
+        def fetchone(self) -> dict[str, object]:
+            """Return one dict row shaped like psycopg2 RealDictCursor output."""
+            return {
+                "well_id": "POZO-001",
+                "as_of_date": date(2024, 3, 1),
+                "gas_production_current": Decimal("75.0"),
+                "gas_production_avg_3m": Decimal("90.0"),
+                "gas_production_avg_6m": Decimal("85.0"),
+                "gas_production_trend_3m": Decimal("-2.5"),
+                "oil_production_current": Decimal("12.0"),
+                "water_production_current": Decimal("4.0"),
+                "producing_days_available": 28,
+                "production_months_available": 6,
+                "formation": "Vaca Muerta",
+                "basin": "Neuquina",
+                "resource_type": "Shale",
+            }
+
+    class Connection:
+        """Minimal connection fake returning the cursor above."""
+
+        def cursor(self) -> Cursor:
+            """Return a DB-API cursor fake."""
+            return Cursor()
+
+    monkeypatch.setenv("ML_FEATURE_STORE_SCHEMA", "custom_features")
+    repository = PostgresFeatureRepository(Connection)
+
+    row = repository.lookup_features("POZO-001", date(2024, 4, 1))
+
+    assert row is not None
+    assert row.as_of_date == date(2024, 3, 1)
+    assert "custom_features.well_monthly_features" in captured["query"]
+    assert "as_of_date <= %s" in captured["query"]
+    assert "order by as_of_date desc" in captured["query"].lower()
+    assert captured["params"] == ("POZO-001", date(2024, 4, 1))
+
+
+def test_dbt_feature_model_is_incremental_and_idempotent() -> None:
+    """Persist feature rows at the expected well/date grain."""
+
+    model_path = Path(
+        "data_platform/transform/models/ml_features/well_monthly_features.sql"
+    )
+
+    model_sql = model_path.read_text(encoding="utf-8")
+
+    assert "schema='ml_features'" in model_sql
+    assert "materialized='incremental'" in model_sql
+    assert "incremental_strategy='merge'" in model_sql
+    assert "unique_key=['well_id', 'as_of_date']" in model_sql
+
+
+def test_dbt_feature_model_prevents_temporal_leakage() -> None:
+    """Only use production records available at or before each feature date."""
+
+    model_path = Path(
+        "data_platform/transform/models/ml_features/well_monthly_features.sql"
+    )
+
+    model_sql = model_path.read_text(encoding="utf-8").lower()
+
+    assert "history.periodo <= feature_dates.as_of_date" in model_sql
+    assert "future" not in model_sql


### PR DESCRIPTION
## Resumen

PR 2 de Fase 3. Implementa la base del feature store persistido sobre Postgres/dbt y el contrato Python para lookup de features desde training e inferencia.

Incluye:
- modelo dbt incremental `ml_features.well_monthly_features` con merge idempotente por `well_id` + `as_of_date`
- metadata/tests dbt del modelo de features
- `ml/features/store.py` con `FeatureRow`, `FeatureStore`, `InMemoryFeatureRepository`, `PostgresFeatureRepository` y `FeatureNotFoundError`
- tests de lookup point-in-time, ausencia de leakage temporal, idempotencia y SQL de Postgres
- ADR-21 actualizado a aceptado con confirmacion PR2
- handoff PR2 actualizado en `docs/planes/fase-3.md`

## Validacion

- `uv run pytest tests/test_feature_store.py` -> 7 passed
- `uv run black --config .pre-commit/.black.toml --check ml/features/store.py tests/test_feature_store.py`
- `uv run flake8 --config .pre-commit/.flake8 ml/features/store.py tests/test_feature_store.py`
- `uv run pylint --rcfile .pre-commit/.pylintrc --persistent=n ml/features/store.py tests/test_feature_store.py` -> 10.00/10
- `uv run mypy --config-file .pre-commit/mypy.ini ml/features/store.py tests/test_feature_store.py`
- `uv run --group data dbt parse --project-dir data_platform/transform --profiles-dir data_platform/transform` -> passed con warning existente de config path `models.ingenieria_software.bronze`

## Notas

Este PR queda apilado sobre PR1 (`feature/mlops-foundation`). Cuando PR1 se mergee a `develop`, rebasear o retargetear este PR contra `develop`.

No ejecuta `dbt build` contra warehouse live para evitar mutaciones fuera del alcance local; PR2 deja materializacion via dbt y lookup Python listos.